### PR TITLE
ci(pages): add CNAME for voxdmr.jcalado.com

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+voxdmr.jcalado.com


### PR DESCRIPTION
## Summary
- Add `public/CNAME` so the GitHub Pages deploy serves at the custom domain `voxdmr.jcalado.com`.

GitHub Pages has been enabled (build_type: workflow) and the custom domain set on the repo. The Vite build copies `public/` into `dist/`, so the CNAME will land in the Pages artifact uploaded by `.github/workflows/deploy.yml`.

## Follow-ups
- Configure DNS: add a `CNAME` record for `voxdmr` → `jcalado.github.io` (already used as the Pages host).
- Once DNS propagates and the cert is issued, enable HTTPS enforcement.

## Test plan
- [ ] CI deploy workflow succeeds on merge to main
- [ ] `voxdmr.jcalado.com` resolves to the deployed site once DNS is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)