### PR TITLE
docs(readme): add download pointers + fix site URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # VoxDMR Site
 
-Landing page and documentation site for [VoxDMR](https://voxdmr.app) — a desktop app for streaming audio to BrandMeister DMR talkgroups via the Rewind protocol. Runs on Linux and Windows.
+Landing page and documentation site for [VoxDMR](https://voxdmr.jcalado.com) — a desktop app for streaming audio to BrandMeister DMR talkgroups via the Rewind protocol. Runs on Linux and Windows.
+
+The site is published at **[voxdmr.jcalado.com](https://voxdmr.jcalado.com)**.
+
+## Get VoxDMR
+
+- **Download** the latest release: [github.com/jcalado/dmr-input/releases](https://github.com/jcalado/dmr-input/releases) — Linux and Windows binaries.
+- **Install guide:** see [voxdmr.jcalado.com/docs/installation](https://voxdmr.jcalado.com/docs/installation).
+- **Source for the app:** [jcalado/dmr-input](https://github.com/jcalado/dmr-input). This repo only contains the website.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
- Replace the dead `voxdmr.app` link with the canonical `voxdmr.jcalado.com`.
- Add a **Get VoxDMR** section pointing to the GitHub release binaries, the install guide, and the app source repo, so anyone landing on this repo's README knows where to actually grab the app.

## Test plan
- [ ] README renders cleanly on github.com
- [ ] Links resolve (`voxdmr.jcalado.com`, `voxdmr.jcalado.com/docs/installation`, `github.com/jcalado/dmr-input/releases`, `github.com/jcalado/dmr-input`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)