### PR TITLE
ui(meta): add OG/Twitter cards using logo.png

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="VoxDMR is a desktop app for streaming audio to BrandMeister DMR talkgroups. Free, open source, runs on Linux and Windows." />
+    <meta name="description" content="VoxDMR is a desktop app for streaming audio to BrandMeister DMR talkgroups. Free to use, runs on Linux and Windows." />
     <title>VoxDMR — Desktop audio for BrandMeister DMR</title>
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://voxdmr.jcalado.com/" />
+    <meta property="og:title" content="VoxDMR — Desktop audio for BrandMeister DMR" />
+    <meta property="og:description" content="VoxDMR is a desktop app for streaming audio to BrandMeister DMR talkgroups. Free to use, runs on Linux and Windows." />
+    <meta property="og:image" content="https://voxdmr.jcalado.com/logo.png" />
+    <meta property="og:image:width" content="1254" />
+    <meta property="og:image:height" content="1254" />
+    <meta property="og:image:alt" content="VoxDMR logo" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="VoxDMR — Desktop audio for BrandMeister DMR" />
+    <meta name="twitter:description" content="VoxDMR is a desktop app for streaming audio to BrandMeister DMR talkgroups. Free to use, runs on Linux and Windows." />
+    <meta name="twitter:image" content="https://voxdmr.jcalado.com/logo.png" />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   </head>


### PR DESCRIPTION
## Summary
Adds Open Graph and Twitter Card meta tags so links shared on WhatsApp, Telegram, Discord, Slack, etc. show a proper preview. Uses `/logo.png` (1254×1254) as the image — plenty of resolution for any platform.

Also drops the stale "open source" wording from the page description to match the recent site-wide copy change ("free to use" — see commits `4fbfa8b`, `ec85196`).

## Test plan
- [ ] After deploy, paste `https://voxdmr.jcalado.com/` into WhatsApp, Telegram, Discord, Slack — confirm preview shows logo + title + description.
- [ ] (Optional) Check via [opengraph.xyz](https://www.opengraph.xyz/url/https%3A%2F%2Fvoxdmr.jcalado.com%2F) or Facebook's Sharing Debugger.