### PR TITLE
fix(domain): use www.voxdmr.com as canonical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ VoxDMR is a landing and documentation site for VoxDMR — a cross-platform app t
 
 ## Architecture
 
-Static site built with Astro. Content is server-rendered to HTML at build time; only the genuinely interactive pieces hydrate as React islands. Deployed to GitHub Pages at the custom domain (`public/CNAME` → voxdmr.com).
+Static site built with Astro. Content is server-rendered to HTML at build time; only the genuinely interactive pieces hydrate as React islands. Deployed to GitHub Pages at the custom domain (`public/CNAME` → www.voxdmr.com).
 
 **Routing & i18n.** File-based routing under `src/pages/`. i18n is **route-based**: English at the root (`/`, `/radios`, `/docs/<slug>`) and Portuguese under `/pt/…`, configured via Astro's `i18n` in `astro.config.mjs` (`defaultLocale: 'en'`, `prefixDefaultLocale: false`). Each page resolves its `lang` from the route and passes it as a prop; the language switcher is a link to the counterpart-locale URL (no client-side language toggle).
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # VoxDMR Site
 
-Landing page and documentation site for [VoxDMR](https://voxdmr.com) — a desktop app for streaming audio to BrandMeister DMR talkgroups via the Rewind protocol. Runs on Linux and Windows.
+Landing page and documentation site for [VoxDMR](https://www.voxdmr.com) — a desktop app for streaming audio to BrandMeister DMR talkgroups via the Rewind protocol. Runs on Linux and Windows.
 
-The site is published at **[voxdmr.com](https://voxdmr.com)**.
+The site is published at **[www.voxdmr.com](https://www.voxdmr.com)**.
 
 ## Get VoxDMR
 
 - **Download** the latest release: [github.com/jcalado/voxdmr-site/releases](https://github.com/jcalado/voxdmr-site/releases) — Linux and Windows binaries.
-- **Install guide:** see [voxdmr.com/docs/installation](https://voxdmr.com/docs/installation).
+- **Install guide:** see [www.voxdmr.com/docs/installation](https://www.voxdmr.com/docs/installation).
 
 ## Bug reports & feature requests
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,7 +25,7 @@ const anchorIcon = {
 
 export default defineConfig({
   output: 'static',
-  site: 'https://voxdmr.com',
+  site: 'https://www.voxdmr.com',
   base: '/',
   image: { service: passthroughImageService() },
   i18n: {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-voxdmr.com
+www.voxdmr.com

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ const {
   ogImage = '/social.jpg',
 } = Astro.props;
 
-const site = Astro.site?.toString().replace(/\/$/, '') ?? 'https://voxdmr.com';
+const site = Astro.site?.toString().replace(/\/$/, '') ?? 'https://www.voxdmr.com';
 const canonical = site + pathname;
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : site + ogImage;
 


### PR DESCRIPTION
Follow-up to #39.

That PR set the site domain to the bare apex `voxdmr.com`, but the GitHub Pages custom domain is **`www.voxdmr.com`** and the apex `voxdmr.com` 301-redirects to it. This points the repo at the actually-served host so canonical tags and the sitemap don't resolve to a redirect.

Changed `voxdmr.com` → `www.voxdmr.com` in:
- `public/CNAME`
- `astro.config.mjs` `site:` (canonical URLs + sitemap)
- `src/layouts/Layout.astro` canonical fallback
- `README.md`, `CLAUDE.md`

Left as-is: the `changelog.md` mentions of `voxdmr.com` (those describe the **app's** reported project URL, a separate codebase) and the `voxdmr@jcalado.com` contact email.

Verified: `npm run build` — 26 pages, sitemap now emits `https://www.voxdmr.com` URLs.