### PR TITLE
fix(ci): bump deploy workflow to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
The Astro 5 → 7 upgrade (#70) requires Node `>=22.12.0`, but the deploy workflow was pinned to `node-version: 20`. The post-merge deploy failed at `astro build`:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Bumps `actions/setup-node` to Node 22. Merging this re-triggers the Pages deploy on a supported runtime.