### PR TITLE
docs(changelog): add v0.13.1 — Homebrew audio routing fix

### DIFF
--- a/src/content/docs/en/changelog.md
+++ b/src/content/docs/en/changelog.md
@@ -2,6 +2,20 @@
 
 Release notes for VoxDMR. Each release page on GitHub has the full commit list and the signed binaries; this is the human summary.
 
+## v0.13.1
+
+::platforms[desktop mobile]
+
+_Released July 2026. Desktop + Android._
+
+A bugfix release for Homebrew ("Others") networks.
+
+- **Homebrew audio routing.** Fixed audio routing on Homebrew ("Others") networks, so
+  transmissions now bridge correctly between masters on the network — ADN, TGIF, FreeDMR, and
+  similar. Affects both desktop and Android. See [Server profiles](./server-profiles).
+
+No config, paths, or protocol semantics changed.
+
 ## v0.13.0
 
 ::platforms[desktop mobile]

--- a/src/content/docs/pt/changelog.md
+++ b/src/content/docs/pt/changelog.md
@@ -2,6 +2,21 @@
 
 Notas de versão do VoxDMR. Cada página de release no GitHub tem a lista completa de commits e os binários assinados; isto é o resumo humano.
 
+## v0.13.1
+
+::platforms[desktop mobile]
+
+_Lançada em julho de 2026. Desktop + Android._
+
+Uma versão de correção de bugs para as redes Homebrew ("Others").
+
+- **Encaminhamento de áudio no Homebrew.** Corrigido o encaminhamento de áudio nas redes
+  Homebrew ("Others"), para que as transmissões passem agora corretamente entre masters na
+  rede — ADN, TGIF, FreeDMR e semelhantes. Afeta o desktop e o Android. Vê
+  [Perfis de servidor](./server-profiles).
+
+Não houve alterações a configuração, caminhos ou semântica de protocolo.
+
 ## v0.13.0
 
 ::platforms[desktop mobile]


### PR DESCRIPTION
Adds a **v0.13.1** entry to the changelog (above v0.13.0), in both `en` and `pt`.

Bugfix release: audio now bridges correctly **between masters** on Homebrew ("Others") networks — ADN, TGIF, FreeDMR, and similar. Affects both desktop and Android.

- Matches the existing changelog format (`::platforms[desktop mobile]` badge, release line, bullet, closing note).
- Links to [Server profiles](./server-profiles), consistent with the v0.13.0 Homebrew "cross-master TX/RX" language.