### PR TITLE
docs(talkgroups): embed PoC scan how-to video

### DIFF
--- a/src/content/docs/en/talkgroups.md
+++ b/src/content/docs/en/talkgroups.md
@@ -175,6 +175,8 @@ Open the talkgroup picker and use a favourite row's **overflow menu → Add to s
 
 ![The same picker with the 92 Europe overflow menu open on a Hytera P50 PoC radio: an "Add to scan" item with a radar icon highlighted at the top, above Rename, Reorder, and Remove](/screenshots/android-scan-add.webp)
 
+::youtube[yphqum0VsXs]{title="VoxDMR — How to enable scan on PoC radios"}
+
 :::
 
 ### Replying and parking

--- a/src/content/docs/pt/talkgroups.md
+++ b/src/content/docs/pt/talkgroups.md
@@ -175,6 +175,8 @@ Abre o picker de talkgroup e usa o **menu de opções → Add to scan / Remove f
 
 ![O mesmo picker com o menu de opções da linha 92 Europe aberto num rádio PoC Hytera P50: um item "Add to scan" com um ícone de radar destacado no topo, acima de Rename, Reorder e Remove](/screenshots/android-scan-add.webp)
 
+::youtube[yphqum0VsXs]{title="VoxDMR — Como ativar o scan em rádios PoC"}
+
 :::
 
 ### Responder e estacionar

--- a/src/docs/docs.css
+++ b/src/docs/docs.css
@@ -108,6 +108,10 @@
 .prose img:hover { opacity: 0.85; }
 .prose strong { color: white; font-weight: 600; }
 
+/* Embedded video (::youtube directive) */
+.prose .video-embed { position: relative; width: 100%; max-width: 560px; aspect-ratio: 16 / 9; margin: 0 0 1.5rem 0; border-radius: 0.75rem; overflow: hidden; border: 1px solid rgba(255, 255, 255, 0.07); background: #0F172A; }
+.prose .video-embed iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+
 /* Image modal */
 .doc-modal-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: rgba(0, 0, 0, 0.85); backdrop-filter: blur(4px); cursor: zoom-out; }
 .doc-modal-img { max-height: 90vh; max-width: 90vw; border-radius: 0.75rem; object-fit: contain; view-transition-name: doc-image; }

--- a/src/lib/remark-platform.ts
+++ b/src/lib/remark-platform.ts
@@ -25,6 +25,10 @@ function langFromPath(path: string | undefined): "en" | "pt" {
  *     → <p class="ver-badges"><span class="ver-badge ver-badge--desktop">…</span> …</p>
  *       Labels are localized from the file's locale (en/pt).
  *
+ *   ::youtube[VIDEO_ID]{title="…"}        leaf directive (embedded video)
+ *     → <div class="video-embed"><iframe src="…youtube-nocookie.com/embed/ID" …></iframe></div>
+ *       Responsive 16:9 embed styled by .video-embed in docs.css.
+ *
  * Replaces the brittle "name a heading exactly Desktop/Android" convention with
  * explicit, authored directives, and keeps everything in Astro's renderer.
  */
@@ -46,6 +50,35 @@ export function remarkPlatform() {
           node.data.hName = "div";
           node.data.hProperties = { class: `callout callout--${name}` };
         }
+        return;
+      }
+
+      if (node.type === "leafDirective" && node.name === "youtube") {
+        // ::youtube[VIDEO_ID]{title="…"} → responsive privacy-friendly embed.
+        const id = (node.children ?? [])
+          .map((c: any) => c.value ?? "")
+          .join("")
+          .trim();
+        const title = String(node.attributes?.title ?? "").trim();
+        node.type = "html";
+        if (/^[\w-]{6,20}$/.test(id)) {
+          const titleAttr = title
+            ? ` title="${title.replace(/"/g, "&quot;")}"`
+            : "";
+          node.value =
+            `<div class="video-embed">` +
+            `<iframe src="https://www.youtube-nocookie.com/embed/${id}"${titleAttr} ` +
+            `loading="lazy" frameborder="0" ` +
+            `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" ` +
+            `referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>` +
+            `</div>`;
+        } else {
+          node.value = "";
+        }
+        delete node.children;
+        delete node.name;
+        delete node.attributes;
+        delete node.data;
         return;
       }
 


### PR DESCRIPTION
Embeds the "How to enable scan on PoC radios" video in the mobile **Flagging favourites for scan** section of the Talkgroups docs.

- **New `::youtube[VIDEO_ID]{title="…"}` leaf directive** in `remarkPlatform` — emits a lazy-loaded, privacy-friendly (`youtube-nocookie.com`) responsive iframe. Video ID is validated to a safe charset.
- **`.video-embed` styles** in `docs.css` — 16:9 aspect ratio, max 560px, rounded corners + border matching the docs aesthetic.
- Placed inside the `:::mobile` block (EN + PT), so it only shows in the Android/PoC compact view, right after the two scan-flagging screenshots.

Build passes; the iframe renders inside the `data-platform="mobile"` container.
