### PR TITLE
docs(changelog): add v0.13.2 release entry

### DIFF
--- a/src/content/docs/en/changelog.md
+++ b/src/content/docs/en/changelog.md
@@ -2,6 +2,27 @@
 
 Release notes for VoxDMR. Each release page on GitHub has the full commit list and the signed binaries; this is the human summary.
 
+## v0.13.2
+
+::platforms[desktop mobile]
+
+_Released July 2026. Desktop + Android._
+
+A small bugfix and polish release across both platforms.
+
+- **Scan notification tracks the active talkgroup (Android).** While scanning, the
+  playback notification now updates to show the talkgroup you're actually hearing instead
+  of the armed set. See [Talkgroups](./talkgroups).
+- **Accessibility disclosure (Android).** The About screen now surfaces the accessibility
+  disclosure.
+- **Windows DMR ID database update fixed (desktop).** Updating the offline DMR ID database
+  no longer fails on Windows with "os error 5" (access denied). See
+  [Talkgroups](./talkgroups).
+- **About blurb broadened (desktop).** The About text now describes VoxDMR beyond
+  BrandMeister, reflecting support for other DMR networks.
+
+No config, paths, or protocol semantics changed.
+
 ## v0.13.1
 
 ::platforms[desktop mobile]

--- a/src/content/docs/pt/changelog.md
+++ b/src/content/docs/pt/changelog.md
@@ -2,6 +2,27 @@
 
 Notas de versão do VoxDMR. Cada página de release no GitHub tem a lista completa de commits e os binários assinados; isto é o resumo humano.
 
+## v0.13.2
+
+::platforms[desktop mobile]
+
+_Lançada em julho de 2026. Desktop + Android._
+
+Uma pequena versão de correções e afinações em ambas as plataformas.
+
+- **A notificação de scan segue o talkgroup ativo (Android).** Durante o scan, a notificação
+  de reprodução passa a mostrar o talkgroup que estás mesmo a ouvir, em vez do conjunto
+  armado. Vê [Talkgroups](./talkgroups).
+- **Divulgação de acessibilidade (Android).** O ecrã Sobre passa a apresentar a divulgação
+  de acessibilidade.
+- **Corrigida a atualização da base de dados de DMR IDs no Windows (desktop).** Atualizar a
+  base de dados de DMR IDs offline já não falha no Windows com "os error 5" (acesso negado).
+  Vê [Talkgroups](./talkgroups).
+- **Texto do Sobre alargado (desktop).** O texto do ecrã Sobre passa a descrever o VoxDMR
+  para além da BrandMeister, refletindo o suporte a outras redes DMR.
+
+Não houve alterações a configuração, caminhos ou semântica de protocolo.
+
 ## v0.13.1
 
 ::platforms[desktop mobile]


### PR DESCRIPTION
Adds the v0.13.2 changelog entry to both `en` and `pt`, in structural parity above v0.13.1.

Bullets map to the release commits:
- #108 — scan notification tracks the playing talkgroup (Android)
- #107 — accessibility disclosure on the About screen (Android)
- #105 — DMR ID DB update no longer fails on Windows / os error 5 (desktop)
- #106 — About blurb broadened beyond BrandMeister (desktop)