### PR TITLE
docs: v0.14.0 changelog + single-firmware-file corrections

### DIFF
--- a/src/content/docs/en/changelog.md
+++ b/src/content/docs/en/changelog.md
@@ -2,6 +2,47 @@
 
 Release notes for VoxDMR. Each release page on GitHub has the full commit list and the signed binaries; this is the human summary.
 
+## v0.14.0
+
+::platforms[desktop mobile]
+
+_Released July 2026. Desktop + Android._
+
+Louder receive audio, a QSO log with locations and QRZ links, backups that include your
+settings, and a much faster vocoder.
+
+- **Louder receive audio.** Auto-levelling aims higher, so received audio sounds like a
+  radio instead of a whisper, and a new **RX boost (+6 dB)** adds more for noisy
+  environments. ⚠️ **Upgrading desktop from 0.13.x?** Tick the RX AGC checkbox once — your
+  saved config has it switched off. See [Audio settings](./audio-settings).
+- **Back up everything.** Backups now include all your app settings, not just profiles.
+  Desktop: **Back up all…**; Android: **Settings → Backup & restore**. See
+  [Server profiles](./server-profiles).
+- **The QSO log grew up.** Callsigns link out to **QRZ.com**, and city, state, country and
+  country flags are available as columns. Desktop columns are resizable and rows open a
+  detail view.
+- **Bluetooth PTT accessories (Android).** External PTT accessories such as the Inrico B01
+  now work, with proper hold-to-talk, and the Bluetooth mic gets its own level slider. See
+  [PTT modes](./ptt-modes).
+- **A much faster vocoder.** Transmit encoding is several times faster, clearing up the
+  choppy TX audio on slower phones. Audio quality is unchanged.
+- **Make it look how you want.** A new Interface screen on both platforms: colours for the
+  call card, talkgroup badge and PTT button, plus text-size controls.
+- **`voxdmr://` links (desktop).** Clicking a `voxdmr://tg/91` link opens VoxDMR straight
+  onto that talkgroup.
+- **One firmware file instead of two.** First-launch setup is a smaller download. Existing
+  installs are unaffected. See [Installation](./installation).
+- **The Homebrew server list updates itself.** A **Refresh** button pulls the current
+  community server directory without waiting for an app update. See
+  [Server profiles](./server-profiles).
+- **Clearer settings (Android).** Plain-language labels, with the details behind a tappable
+  **(i)**. Car mode settings are grouped, and a battery-optimization shortcut sits under
+  Display & power.
+- **Fixes.** Receive latency no longer creeps upward the longer you listen, and the RX meter
+  tracks what you're actually hearing. Scan clears properly on disconnect and stays
+  reachable during a call. On PoC radios, the LEX knob steps one favourite per detent and
+  the Motorola ION's channel rocker works. See [Radios](../radios).
+
 ## v0.13.2
 
 ::platforms[desktop mobile]

--- a/src/content/docs/en/installation.md
+++ b/src/content/docs/en/installation.md
@@ -88,13 +88,11 @@ The first time VoxDMR Desktop starts, it shows a one-shot setup card because the
 
 You have two choices:
 
-**Auto-download** (recommended). Click **Download (≈2 MB)**. VoxDMR fetches:
-- `D002.032.bin` (994 KB) from [md380.org](https://md380.org/firmware/orig/TYT-Tytera-MD-380-FW-v232.zip), unwrapped from the OEM update format.
-- `d02032-core.img` (128 KB) from the [upstream md380_vocoder_dynarmic project on GitHub](https://github.com/nostar/md380_vocoder_dynarmic).
+**Auto-download** (recommended). Click **Download**. VoxDMR fetches a single file — `D002.032.bin` (994 KB) — from [md380.org](https://md380.org/firmware/orig/TYT-Tytera-MD-380-FW-v232.zip), unwrapped from the OEM update format. It's SHA-256 verified before being written to disk, and the whole thing takes a few seconds on a normal connection.
 
-Both downloads are SHA-256 verified before being written to disk. The whole thing takes a few seconds on a normal connection.
+**Choose existing files**: if your machine can't reach the download URL (corporate proxy, offline, restricted firewall), click **Choose existing files…** and pick `D002.032.bin` from somewhere on disk. It's copied into the data directory and SHA-verified the same way.
 
-**Choose existing files**: if your machine can't reach the download URLs (corporate proxy, offline, restricted firewall), click **Choose existing files…** and pick `D002.032.bin` and `d02032-core.img` from somewhere on disk. They're copied into the data directory and SHA-verified the same way.
+> **Upgrading from v0.13.x or earlier?** Setup used to fetch a second file, `d02032-core.img` (a 128 KB dump of a running radio's SRAM). As of v0.14.0 the load-bearing part of that image is compiled into VoxDMR, so it's **no longer downloaded or required**. An existing copy on disk is still preferred and SHA-verified, so nothing breaks on an upgrade — you just don't need it on a fresh install. (The **Choose existing files…** picker filters on `.bin`, so it only offers `D002.032.bin` anyway.) See the [changelog](./changelog).
 
 Once setup completes, the main UI mounts and the firmware is loaded for every subsequent launch.
 

--- a/src/content/docs/en/troubleshooting.md
+++ b/src/content/docs/en/troubleshooting.md
@@ -149,8 +149,10 @@ Set it in **Settings → Scan → Hang time**.
 
 The vocoder firmware isn't installed yet, or the install location isn't where VoxDMR is looking. The setup card lets you fix this two ways:
 
-- **Download (≈2 MB)**: the easy path; works on any machine with internet access to `md380.org` and `raw.githubusercontent.com`.
-- **Choose existing files**: for offline machines or restrictive networks. Point VoxDMR at `D002.032.bin` and `d02032-core.img` on disk.
+- **Download**: the easy path; works on any machine with internet access to `md380.org`.
+- **Choose existing files**: for offline machines or restrictive networks. Point VoxDMR at `D002.032.bin` on disk.
+
+Since v0.14.0 only `D002.032.bin` is required — the old second file, `d02032-core.img`, is compiled in and no longer downloaded. An existing copy is still used if you have one.
 
 If you have the files in a non-default location, set `VOXDMR_FIRMWARE_DIR` to point at the directory before launching:
 
@@ -164,7 +166,7 @@ A firmware file got corrupted (partial download, disk error, accidentally edited
 
 ### Auto-download fails behind a corporate proxy
 
-`ureq` (the HTTPS client VoxDMR uses) doesn't read system proxy settings. Either use the **Choose existing files** path with manually-downloaded files, or run VoxDMR from a network that allows direct outbound HTTPS to the two source hosts.
+`ureq` (the HTTPS client VoxDMR uses) doesn't read system proxy settings. Either use the **Choose existing files** path with a manually-downloaded `D002.032.bin`, or run VoxDMR from a network that allows direct outbound HTTPS to `md380.org`.
 
 ## Activity dots stay gray
 

--- a/src/content/docs/pt/changelog.md
+++ b/src/content/docs/pt/changelog.md
@@ -2,6 +2,51 @@
 
 Notas de versão do VoxDMR. Cada página de release no GitHub tem a lista completa de commits e os binários assinados; isto é o resumo humano.
 
+## v0.14.0
+
+::platforms[desktop mobile]
+
+_Lançada em julho de 2026. Desktop + Android._
+
+Áudio recebido mais alto, um registo de QSOs com localizações e ligações ao QRZ, cópias de
+segurança que incluem as tuas definições, e um vocoder muito mais rápido.
+
+- **Áudio recebido mais alto.** O nivelamento automático aponta mais alto, para o áudio
+  recebido soar como um rádio e não como um sussurro, e uma nova opção
+  **Reforço de RX (+6 dB)** acrescenta mais para ambientes ruidosos.
+  ⚠️ **Vens da 0.13.x no desktop?** Liga a caixa do AGC de RX uma vez — a tua configuração
+  gravada tem-na desligada. Vê [Definições de áudio](./audio-settings).
+- **Guardar tudo.** As cópias de segurança passam a incluir todas as definições da
+  aplicação, não só os perfis. Desktop: **Guardar tudo…**; Android: **Definições → Cópia de
+  segurança e restauro**. Vê [Perfis de servidor](./server-profiles).
+- **O registo de QSOs cresceu.** Os indicativos passam a ligar para o **QRZ.com**, e a
+  cidade, o distrito/estado, o país e as bandeiras estão disponíveis como colunas. No
+  desktop as colunas redimensionam-se e as linhas abrem uma vista de detalhe.
+- **Acessórios de PTT Bluetooth (Android).** Acessórios de PTT externos como o Inrico B01
+  passam a funcionar, com carregar-para-falar a sério, e o microfone Bluetooth ganha o seu
+  próprio cursor de nível. Vê [Modos de PTT](./ptt-modes).
+- **Um vocoder muito mais rápido.** A codificação de transmissão é várias vezes mais rápida,
+  resolvendo o áudio de TX entrecortado nos telemóveis mais lentos. A qualidade do áudio não
+  muda.
+- **Põe-no com o aspeto que quiseres.** Um novo ecrã Interface em ambas as plataformas:
+  cores para o cartão de chamada, o distintivo de talkgroup e o botão de PTT, mais controlo
+  do tamanho do texto.
+- **Ligações `voxdmr://` (desktop).** Clicar numa ligação `voxdmr://tg/91` abre o VoxDMR
+  diretamente nesse talkgroup.
+- **Um ficheiro de firmware em vez de dois.** A configuração inicial é uma transferência
+  mais pequena. As instalações existentes não são afetadas. Vê [Instalação](./installation).
+- **A lista de servidores Homebrew atualiza-se sozinha.** Um botão **Atualizar** vai buscar
+  o diretório de servidores da comunidade sem esperar por uma atualização da aplicação. Vê
+  [Perfis de servidor](./server-profiles).
+- **Definições mais claras (Android).** Etiquetas em linguagem simples, com os detalhes
+  atrás de um **(i)** tocável. As definições do Modo condução estão agrupadas, e um atalho
+  para a otimização de bateria passa a estar em Ecrã e energia.
+- **Correções.** A latência de receção já não vai subindo quanto mais tempo ouves, e o
+  medidor de RX acompanha o que estás mesmo a ouvir. O scan é limpo corretamente ao
+  desligar e mantém-se acessível durante uma chamada. Nos rádios PoC, o botão rotativo dos
+  LEX salta um favorito por retenção e o balancim de canal do Motorola ION funciona. Vê
+  [Rádios](../radios).
+
 ## v0.13.2
 
 ::platforms[desktop mobile]

--- a/src/content/docs/pt/installation.md
+++ b/src/content/docs/pt/installation.md
@@ -88,13 +88,11 @@ Na primeira execução do VoxDMR Desktop aparece um cartão de configuração ú
 
 Tens duas opções:
 
-**Auto-download** (recomendado). Clica em **Transferir (≈2 MB)**. O VoxDMR vai buscar:
-- `D002.032.bin` (994 KB) a [md380.org](https://md380.org/firmware/orig/TYT-Tytera-MD-380-FW-v232.zip), desempacotado do formato OEM.
-- `d02032-core.img` (128 KB) ao [projeto md380_vocoder_dynarmic no GitHub](https://github.com/nostar/md380_vocoder_dynarmic).
+**Auto-download** (recomendado). Clica em **Transferir**. O VoxDMR vai buscar um único ficheiro — o `D002.032.bin` (994 KB) — a [md380.org](https://md380.org/firmware/orig/TYT-Tytera-MD-380-FW-v232.zip), desempacotado do formato OEM. É verificado por SHA-256 antes de ser escrito no disco, e o processo demora alguns segundos numa ligação normal.
 
-Ambos são verificados por SHA-256 antes de serem escritos no disco. O processo demora alguns segundos numa ligação normal.
+**Escolher ficheiros existentes**: se a tua máquina não conseguir aceder ao URL (proxy corporativo, offline, firewall restritivo), clica em **Escolher ficheiros existentes…** e seleciona o `D002.032.bin` no disco. É copiado para o diretório de dados e verificado por SHA-256 da mesma forma.
 
-**Escolher ficheiros existentes**: se a tua máquina não conseguir aceder aos URLs (proxy corporativo, offline, firewall restritivo), clica em **Escolher ficheiros existentes…** e seleciona `D002.032.bin` e `d02032-core.img` no disco. São copiados para o diretório de dados e verificados por SHA-256 da mesma forma.
+> **Vens da v0.13.x ou anterior?** A configuração inicial ia buscar um segundo ficheiro, o `d02032-core.img` (um dump de 128 KB da SRAM de um rádio em funcionamento). A partir da v0.14.0 a parte essencial dessa imagem está compilada dentro do VoxDMR, por isso **já não é transferida nem necessária**. Uma cópia que já esteja em disco continua a ser preferida e verificada por SHA, portanto nada quebra numa atualização — simplesmente deixa de ser preciso numa instalação nova. (O seletor **Escolher ficheiros existentes…** filtra por `.bin`, por isso só apresenta o `D002.032.bin`.) Vê o [registo de alterações](./changelog).
 
 Depois da configuração concluída, o UI principal aparece e o firmware é carregado em todos os arranques seguintes.
 

--- a/src/content/docs/pt/troubleshooting.md
+++ b/src/content/docs/pt/troubleshooting.md
@@ -149,8 +149,10 @@ Define-o em **Settings → Scan → Hang time**.
 
 O firmware do vocoder ainda não está instalado, ou o local de instalação não é onde o VoxDMR procura. O ecrã de setup deixa-te resolver isto de duas formas:
 
-- **Download (≈2 MB)**: caminho fácil; funciona em qualquer máquina com acesso à internet a `md380.org` e `raw.githubusercontent.com`.
-- **Choose existing files**: para máquinas offline ou redes restritivas. Aponta o VoxDMR para `D002.032.bin` e `d02032-core.img` em disco.
+- **Download**: caminho fácil; funciona em qualquer máquina com acesso à internet a `md380.org`.
+- **Choose existing files**: para máquinas offline ou redes restritivas. Aponta o VoxDMR para o `D002.032.bin` em disco.
+
+Desde a v0.14.0 só o `D002.032.bin` é necessário — o antigo segundo ficheiro, `d02032-core.img`, está compilado dentro da aplicação e já não é transferido. Uma cópia existente continua a ser usada, se a tiveres.
 
 Se tens os ficheiros num local não predefinido, define `VOXDMR_FIRMWARE_DIR` a apontar para a diretoria antes de lançar:
 
@@ -164,7 +166,7 @@ Um ficheiro de firmware ficou corrompido (download parcial, erro de disco, ediç
 
 ### Download automático falha atrás de proxy corporativo
 
-O `ureq` (o cliente HTTPS que o VoxDMR usa) não lê as definições de proxy do sistema. Ou usa o caminho **Choose existing files** com ficheiros descarregados manualmente, ou corre o VoxDMR a partir de uma rede que permita HTTPS direto para os dois hosts de origem.
+O `ureq` (o cliente HTTPS que o VoxDMR usa) não lê as definições de proxy do sistema. Ou usa o caminho **Choose existing files** com um `D002.032.bin` descarregado manualmente, ou corre o VoxDMR a partir de uma rede que permita HTTPS direto para o `md380.org`.
 
 ## Pontos de atividade ficam cinza
 


### PR DESCRIPTION
## What

- **v0.14.0 changelog entry** (`en` + `pt`) — the site was still topped out at v0.13.2 while the app repo has had a `v0.14.0` tag since 2026-07-28 (44 commits past v0.13.2).
- **Firmware docs corrected.** `#152` compiled the vocoder's SRAM init state in and dropped the `d02032-core.img` download, which left `installation.md` and `troubleshooting.md` actively instructing users to fetch or pick a file that setup no longer wants.

## Changelog

Eleven bullets, outcome-first — no implementation detail. Ordered by what users notice: louder RX audio, full settings backup, QSO log (QRZ / location / flags), Bluetooth PTT accessories, faster vocoder, Interface customization, `voxdmr://` links, one firmware file, self-updating Homebrew list, clearer Android settings, fixes.

## Firmware corrections

| | Before | After |
|---|---|---|
| Auto-download | two files, incl. `d02032-core.img` from nostar/md380_vocoder_dynarmic | one file, `D002.032.bin` (994 KB) from md380.org |
| Manual pick | "pick `D002.032.bin` and `d02032-core.img`" | `D002.032.bin` only (the rfd picker filters on `.bin`) |
| Proxy/firewall hosts | `md380.org` and `raw.githubusercontent.com` | `md380.org` (the GitHub URL is gone from the source) |

An upgrader note explains that an existing `d02032-core.img` is still preferred and SHA-verified, so nothing breaks on upgrade.

## Notes

- `npm run lint` clean; `en`/`pt` kept in structural parity (11 bullets, same links and directives).
- Companion change in the app repo, **not** included here: `setup.idle.download` still says "Download (≈2 MB)" and the firmware size strings said `~1.1 MB` (the old two-file total) — corrected to `~1 MB` in `app.yml` and the Android ARBs.
- Still open: the v0.13.0 entry's "Manual audio levels by default" bullet claims RX auto-levelling shipped defaulting **off**, which appears to be wrong. Not touched here.