### PR TITLE
feat(download): unify the CTAs behind a single download menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Thumbs.db
 .superpowers
 docs/superpowers/
 .astro/
+.playwright-mcp/

--- a/src/components/CtaBar.astro
+++ b/src/components/CtaBar.astro
@@ -1,12 +1,9 @@
 ---
-import Smartphone from "@/src/components/icons/Smartphone.astro";
-import Monitor from "@/src/components/icons/Monitor.astro";
 import MessageCircle from "@/src/components/icons/MessageCircle.astro";
 import Coffee from "@/src/components/icons/Coffee.astro";
+import DownloadMenu from "@/src/islands/DownloadMenu.tsx";
 import { getT, type Lang } from "@/src/i18n/t";
 
-const PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.jcalado.voxdmr";
-const RELEASES_URL = "https://github.com/jcalado/voxdmr-site/releases/latest";
 const TELEGRAM_URL = "https://t.me/+6-ncS_eluTUxNmU0";
 const KOFI_URL = "https://ko-fi.com/jcalado";
 
@@ -26,14 +23,12 @@ const t = getT(lang);
 <div
   class={`grid w-full grid-cols-2 gap-1.5 rounded-3xl border border-border bg-surface-raised/40 p-1.5 sm:inline-flex sm:w-auto sm:flex-wrap sm:items-center sm:gap-1.5 sm:rounded-full ${className}`}
 >
-  <a href={PLAY_STORE_URL} target="_blank" rel="noopener noreferrer" class={`${SEGMENT} bg-vibrant-red hover:bg-red-500 text-white font-bold`}>
-    <Smartphone class="w-5 h-5" />
-    {t("cta.android")}
-  </a>
-  <a href={RELEASES_URL} target="_blank" rel="noopener noreferrer" class={`${SEGMENT} bg-white/10 hover:bg-white/[0.15] text-white font-bold`}>
-    <Monitor class="w-5 h-5" />
-    {t("cta.desktop")}
-  </a>
+  <DownloadMenu
+    lang={lang}
+    className="col-span-2 sm:col-span-1"
+    triggerClassName={`${SEGMENT} w-full sm:w-auto bg-vibrant-red hover:bg-red-500 text-white font-bold`}
+    client:load
+  />
   <a href={TELEGRAM_URL} target="_blank" rel="noopener noreferrer" class={`${SEGMENT} bg-white/5 hover:bg-white/10 text-on-surface font-semibold`}>
     <MessageCircle class="w-5 h-5" />
     {t("cta.community")}

--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -1,6 +1,7 @@
 ---
 import Logo from "@/src/components/Logo.astro";
 import LanguageSwitcher from "@/src/components/LanguageSwitcher.astro";
+import DownloadMenu from "@/src/islands/DownloadMenu.tsx";
 import Menu from "@/src/components/icons/Menu.astro";
 import X from "@/src/components/icons/X.astro";
 import { getT, type Lang } from "@/src/i18n/t";
@@ -39,12 +40,13 @@ const navLinks = [
 
     <div class="flex items-center gap-3 lg:gap-4">
       <LanguageSwitcher lang={lang} pathname={pathname} />
-      <a
-        href={`${homePrefix}/#download`}
-        class="btn-press hidden lg:inline-flex bg-vibrant-red hover:bg-red-500 text-white px-6 lg:px-8 py-2.5 lg:py-3 rounded-2xl font-bold hover:scale-105 transition-all"
-      >
-        {t("nav.getApp")}
-      </a>
+      <DownloadMenu
+        lang={lang}
+        align="right"
+        className="hidden lg:block"
+        triggerClassName="btn-press inline-flex items-center gap-2 bg-vibrant-red hover:bg-red-500 text-white px-5 lg:px-6 py-2.5 lg:py-3 rounded-2xl font-bold hover:scale-105 transition-all"
+        client:load
+      />
       <button
         type="button"
         class="lg:hidden text-on-surface-muted hover:text-white transition-colors p-1.5 -mr-1.5"

--- a/src/components/landing/CtaSection.astro
+++ b/src/components/landing/CtaSection.astro
@@ -1,9 +1,8 @@
 ---
 import Logo from "@/src/components/Logo.astro";
-import Smartphone from "@/src/components/icons/Smartphone.astro";
-import Monitor from "@/src/components/icons/Monitor.astro";
 import BookOpen from "@/src/components/icons/BookOpen.astro";
 import Coffee from "@/src/components/icons/Coffee.astro";
+import DownloadMenu from "@/src/islands/DownloadMenu.tsx";
 import { getT, type Lang } from "@/src/i18n/t";
 import { localizePath } from "@/src/i18n/routing";
 
@@ -26,21 +25,13 @@ const docsHref = localizePath("/docs", lang);
       {t("cta.description")}
     </p>
 
-    <div class="flex flex-col sm:flex-row items-stretch sm:items-end justify-center gap-6 sm:gap-8">
-      <div class="flex flex-col gap-2.5 items-center">
-        <span class="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-on-surface-muted">{t("cta.onPhone")}</span>
-        <a href="https://play.google.com/store/apps/details?id=com.jcalado.voxdmr" target="_blank" rel="noopener noreferrer" class="btn-press w-full sm:w-auto bg-vibrant-red hover:bg-red-500 text-white font-bold text-lg px-8 lg:px-10 py-4 lg:py-5 rounded-2xl flex items-center justify-center gap-3 transition-all hover:-translate-y-1 whitespace-nowrap">
-          {t("cta.getAndroid")}
-          <Smartphone class="w-5 h-5" />
-        </a>
-      </div>
-      <div class="flex flex-col gap-2.5 items-center">
-        <span class="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-on-surface-muted">{t("cta.onDesktop")}</span>
-        <a href="https://github.com/jcalado/voxdmr-site/releases/latest" target="_blank" rel="noopener noreferrer" class="btn-press w-full sm:w-auto bg-vibrant-red/90 hover:bg-red-500 text-white font-bold text-lg px-8 lg:px-10 py-4 lg:py-5 rounded-2xl flex items-center justify-center gap-3 transition-all hover:-translate-y-1 whitespace-nowrap">
-          {t("cta.getDesktop")}
-          <Monitor class="w-5 h-5" />
-        </a>
-      </div>
+    <div class="flex justify-center">
+      <DownloadMenu
+        lang={lang}
+        className="w-full sm:w-auto"
+        triggerClassName="btn-press w-full sm:w-auto bg-vibrant-red hover:bg-red-500 text-white font-bold text-lg px-8 lg:px-10 py-4 lg:py-5 rounded-2xl inline-flex items-center justify-center gap-3 transition-all hover:-translate-y-1 whitespace-nowrap"
+        client:load
+      />
     </div>
     <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 text-sm">
       <a href={docsHref} class="inline-flex items-center gap-2 text-vibrant-blue hover:text-sky-300 font-semibold transition-colors">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,6 +4,12 @@
   "nav.docs": "Docs",
   "nav.getApp": "Download",
 
+  "download.label": "Download",
+  "download.playStore": "Play Store",
+  "download.windows": "Windows",
+  "download.linuxAppImage": "Linux · AppImage",
+  "download.apk32": "Android APK · 32-bit (PoC)",
+
   "screenshots.heading": "See it in action",
   "screenshots.subheading": "From idle to active RX. Same app on the desktop and on a phone — toggle to switch.",
   "screenshots.zoomOpen": "Zoom in on",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -4,6 +4,12 @@
   "nav.docs": "Documentação",
   "nav.getApp": "Transferir",
 
+  "download.label": "Transferir",
+  "download.playStore": "Play Store",
+  "download.windows": "Windows",
+  "download.linuxAppImage": "Linux · AppImage",
+  "download.apk32": "APK Android · 32-bit (PoC)",
+
   "screenshots.heading": "Vê em ação",
   "screenshots.subheading": "Do idle ao RX ativo. A mesma app no PC e no telemóvel — alterna para trocar.",
   "screenshots.zoomOpen": "Ampliar",

--- a/src/islands/DownloadMenu.tsx
+++ b/src/islands/DownloadMenu.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { LucideIcon } from "lucide-react";
+import { ChevronDown, Cpu, Download, Monitor, Smartphone, Terminal } from "lucide-react";
+import { getT, type Lang } from "@/src/i18n/t";
+
+type DownloadItem = {
+  key: string;
+  labelKey: string;
+  href: string;
+  Icon: LucideIcon;
+  /** Open in a new tab (store / releases pages). Direct asset links download in place. */
+  external?: boolean;
+};
+
+// Download targets. The stable-named desktop assets resolve through GitHub's
+// `/releases/latest/download/<asset>` redirect, so these URLs never need a
+// version bump. The APKs have version-stamped filenames, so the 32-bit build
+// links to the releases page rather than a direct asset.
+const RELEASES = "https://github.com/jcalado/voxdmr-site/releases";
+const DOWNLOADS: DownloadItem[] = [
+  {
+    key: "playStore",
+    labelKey: "download.playStore",
+    href: "https://play.google.com/store/apps/details?id=com.jcalado.voxdmr",
+    Icon: Smartphone,
+    external: true,
+  },
+  {
+    key: "windows",
+    labelKey: "download.windows",
+    href: `${RELEASES}/latest/download/VoxDMR-windows-x86_64.exe`,
+    Icon: Monitor,
+  },
+  {
+    key: "linuxAppImage",
+    labelKey: "download.linuxAppImage",
+    href: `${RELEASES}/latest/download/VoxDMR-linux-x86_64.AppImage`,
+    Icon: Terminal,
+  },
+  {
+    key: "apk32",
+    labelKey: "download.apk32",
+    href: `${RELEASES}/latest`,
+    Icon: Cpu,
+    external: true,
+  },
+];
+
+type DownloadMenuProps = {
+  lang: Lang;
+  /** Classes for the trigger button so it can match each call site's CTA style. */
+  triggerClassName: string;
+  /** Wrapper classes — used to inherit sizing (e.g. `w-full sm:w-auto`). */
+  className?: string;
+  /** Which edge the menu aligns to. */
+  align?: "left" | "right";
+};
+
+export default function DownloadMenu({
+  lang,
+  triggerClassName,
+  className,
+  align = "left",
+}: DownloadMenuProps) {
+  const t = getT(lang);
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const MENU_WIDTH = 256; // matches w-64
+
+  // The menu is portaled to <body> so no `overflow-hidden` ancestor (e.g. the
+  // hero header) can clip it. Position it as a fixed box anchored to the
+  // trigger, re-measuring on scroll/resize while open.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const update = () => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const rawLeft = align === "right" ? r.right - MENU_WIDTH : r.left;
+      const left = Math.max(8, Math.min(rawLeft, window.innerWidth - MENU_WIDTH - 8));
+      setCoords({ top: r.bottom + 8, left });
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open, align]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (!triggerRef.current?.contains(target) && !menuRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div className={className}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={triggerClassName}
+      >
+        <Download className="w-5 h-5" />
+        {t("download.label")}
+        <ChevronDown className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{ top: coords.top, left: coords.left, width: MENU_WIDTH }}
+            className="fixed z-[60] origin-top rounded-2xl border border-border bg-slate-900/95 p-2 shadow-2xl shadow-black/50 backdrop-blur-xl"
+          >
+            {DOWNLOADS.map(({ key, labelKey, href, Icon, external }) => (
+              <a
+                key={key}
+                href={href}
+                role="menuitem"
+                onClick={() => setOpen(false)}
+                {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                className="flex items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-semibold text-on-surface transition-colors hover:bg-white/10 hover:text-white"
+              >
+                <Icon className="w-4 h-4 shrink-0 text-vibrant-blue" />
+                {t(labelKey)}
+              </a>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the Android/Desktop button pair in the nav, the CTA bar and the landing CTA section with a single **Download** dropdown covering all four builds.

## What's in the menu

| Entry | Target |
| --- | --- |
| Play Store | `play.google.com/…?id=com.jcalado.voxdmr` |
| Windows | `releases/latest/download/VoxDMR-windows-x86_64.exe` |
| Linux · AppImage | `releases/latest/download/VoxDMR-linux-x86_64.AppImage` |
| Android APK · 32-bit (PoC) | `releases/latest` (page) |

The desktop assets go through GitHub's `latest/download/<asset>` redirect, so the URLs never need a version bump. The APKs have version-stamped filenames, so the 32-bit entry points at the releases page instead of a direct asset.

## Implementation

`src/islands/DownloadMenu.tsx` is a new React island. The panel is portaled to `<body>` and positioned `fixed` against the trigger's rect, re-measuring on scroll and resize — otherwise the hero header's `overflow-hidden` clips it. Closes on outside pointer-down and on <kbd>Escape</kbd>; `aria-haspopup="menu"` / `aria-expanded` on the trigger, `role="menu"` / `role="menuitem"` on the panel.

Each call site passes its own `triggerClassName`, so the three CTAs keep the styling they had. `align="right"` keeps the nav instance from overflowing the viewport.

Five new `download.*` keys in `en.json` / `pt.json`.

## Notes

- The **mobile** nav menu still links to `/#download` with `nav.getApp` — a dropdown inside the slide-out felt worse than a plain link. Happy to convert it if you disagree.
- `cta.android`, `cta.desktop`, `cta.onPhone`, `cta.onDesktop`, `cta.getAndroid` and `cta.getDesktop` now have no call sites. Left in place for this PR; can be swept separately.
- Second commit ignores `.playwright-mcp/` scratch output.

`npm run lint` and `npm run build` pass.