### PR TITLE
fix(nav): give the phone menu the real download targets

### DIFF
--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -6,6 +6,7 @@ import Menu from "@/src/components/icons/Menu.astro";
 import X from "@/src/components/icons/X.astro";
 import { getT, type Lang } from "@/src/i18n/t";
 import { localizePath } from "@/src/i18n/routing";
+import { downloads } from "@/src/downloads";
 
 const linkClass =
   "nav-link font-medium text-on-surface-muted hover:text-vibrant-red transition-colors px-2 py-1";
@@ -26,6 +27,10 @@ const navLinks = [
   { href: localizePath("/docs", lang), label: t("nav.docs") },
   { href: localizePath("/radios", lang), label: t("nav.radios") },
 ];
+
+// The phone menu leads with the Play Store and demotes the rest.
+const primary = downloads.find((d) => d.key === "playStore")!;
+const secondary = downloads.filter((d) => d.key !== "playStore");
 ---
 <nav class="w-full top-0 sticky z-50 bg-slate-950/80 backdrop-blur-xl h-24 flex items-center border-b border-border">
   <div class="flex justify-between items-center max-w-7xl mx-auto px-6 lg:px-10 w-full">
@@ -78,13 +83,40 @@ const navLinks = [
           {l.label}
         </a>
       ))}
-      <a
-        href={`${homePrefix}/#download`}
-        data-nav-link
-        class="btn-press mt-4 bg-vibrant-red hover:bg-red-500 text-white text-center px-6 py-3 rounded-2xl font-bold transition-colors"
-      >
-        {t("nav.getApp")}
-      </a>
+      {/*
+        The slide-out lists the download targets inline rather than nesting the
+        DownloadMenu dropdown inside it: one tap instead of two, and no overlay
+        stacked on an overlay. The Play Store leads as the primary button since
+        this menu only ever renders on a phone; the rest sit beneath as
+        secondary links. Each carries data-nav-link so the existing tap handler
+        closes the menu.
+      */}
+      <div class="mt-4 flex flex-col items-center gap-3">
+        <span class="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-on-surface-muted">
+          {t("download.label")}
+        </span>
+        <a
+          href={primary.href}
+          data-nav-link
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-press w-full bg-vibrant-red hover:bg-red-500 text-white text-center px-6 py-3 rounded-2xl font-bold transition-colors"
+        >
+          {t(primary.labelKey)}
+        </a>
+        <div class="flex flex-wrap justify-center gap-x-5 gap-y-2 pb-1">
+          {secondary.map((d) => (
+            <a
+              href={d.href}
+              data-nav-link
+              {...(d.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+              class="text-sm font-medium text-on-surface-muted hover:text-white transition-colors"
+            >
+              {t(d.labelKey)}
+            </a>
+          ))}
+        </div>
+      </div>
     </div>
   </div>
 </nav>

--- a/src/downloads.ts
+++ b/src/downloads.ts
@@ -1,0 +1,45 @@
+/**
+ * The download targets, shared by the `DownloadMenu` island and the mobile nav
+ * so the two can't drift apart.
+ *
+ * The desktop assets resolve through GitHub's `/releases/latest/download/<asset>`
+ * redirect, so these URLs never need a version bump. The APKs have
+ * version-stamped filenames, so the 32-bit build links to the releases page
+ * rather than a direct asset.
+ */
+const RELEASES = "https://github.com/jcalado/voxdmr-site/releases";
+
+export interface Download {
+  /** Stable id; also picks the icon in `DownloadMenu`. */
+  key: "playStore" | "windows" | "linuxAppImage" | "apk32";
+  /** i18n key for the visible label, e.g. "download.windows". */
+  labelKey: string;
+  href: string;
+  /** Open in a new tab (store / releases pages). Direct asset links download in place. */
+  external?: boolean;
+}
+
+export const downloads: Download[] = [
+  {
+    key: "playStore",
+    labelKey: "download.playStore",
+    href: "https://play.google.com/store/apps/details?id=com.jcalado.voxdmr",
+    external: true,
+  },
+  {
+    key: "windows",
+    labelKey: "download.windows",
+    href: `${RELEASES}/latest/download/VoxDMR-windows-x86_64.exe`,
+  },
+  {
+    key: "linuxAppImage",
+    labelKey: "download.linuxAppImage",
+    href: `${RELEASES}/latest/download/VoxDMR-linux-x86_64.AppImage`,
+  },
+  {
+    key: "apk32",
+    labelKey: "download.apk32",
+    href: `${RELEASES}/latest`,
+    external: true,
+  },
+];

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2,7 +2,6 @@
   "nav.screenshots": "Screenshots",
   "nav.features": "Features",
   "nav.docs": "Docs",
-  "nav.getApp": "Download",
 
   "download.label": "Download",
   "download.playStore": "Play Store",
@@ -39,10 +38,6 @@
   "hero.joinCommunity": "View on GitHub",
   "nav.getAndroid": "Google Play",
   "nav.getDesktop": "Desktop",
-  "cta.getAndroid": "Get on Google Play",
-  "cta.getDesktop": "Download for Desktop",
-  "cta.onPhone": "On your phone",
-  "cta.onDesktop": "On your computer",
 
   "features.heading": "Built for DMR",
   "features.subheading": "Everything you need to get on the air, on any DMR network you can reach.",
@@ -85,8 +80,6 @@
   "cta.description": "Free to download. No account needed. Install VoxDMR on your phone or PC, enter your DMR ID, and you're on the air.",
   "cta.setupGuide": "Setup Guide",
   "cta.joinCommunity": "Join the Community",
-  "cta.android": "Android",
-  "cta.desktop": "Desktop",
   "cta.community": "Community",
   "cta.donate": "Donate",
 

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -2,7 +2,6 @@
   "nav.screenshots": "Capturas",
   "nav.features": "Funcionalidades",
   "nav.docs": "Documentação",
-  "nav.getApp": "Transferir",
 
   "download.label": "Transferir",
   "download.playStore": "Play Store",
@@ -39,10 +38,6 @@
   "hero.joinCommunity": "Ver no GitHub",
   "nav.getAndroid": "Google Play",
   "nav.getDesktop": "PC",
-  "cta.getAndroid": "Obter no Google Play",
-  "cta.getDesktop": "Transferir para PC",
-  "cta.onPhone": "No teu telemóvel",
-  "cta.onDesktop": "No teu computador",
 
   "features.heading": "Feito para DMR",
   "features.subheading": "Tudo o que precisas para entrar no ar, em qualquer rede DMR ao teu alcance.",
@@ -85,8 +80,6 @@
   "cta.description": "Gratuito para descarregar. Sem necessidade de conta. Instala o VoxDMR no telemóvel ou no PC, introduz o teu ID DMR e estás no ar.",
   "cta.setupGuide": "Guia de Configuração",
   "cta.joinCommunity": "Junta-te à Comunidade",
-  "cta.android": "Android",
-  "cta.desktop": "Desktop",
   "cta.community": "Comunidade",
   "cta.donate": "Doar",
 

--- a/src/islands/DownloadMenu.tsx
+++ b/src/islands/DownloadMenu.tsx
@@ -3,49 +3,14 @@ import { createPortal } from "react-dom";
 import type { LucideIcon } from "lucide-react";
 import { ChevronDown, Cpu, Download, Monitor, Smartphone, Terminal } from "lucide-react";
 import { getT, type Lang } from "@/src/i18n/t";
+import { downloads, type Download as DownloadTarget } from "@/src/downloads";
 
-type DownloadItem = {
-  key: string;
-  labelKey: string;
-  href: string;
-  Icon: LucideIcon;
-  /** Open in a new tab (store / releases pages). Direct asset links download in place. */
-  external?: boolean;
+const ICONS: Record<DownloadTarget["key"], LucideIcon> = {
+  playStore: Smartphone,
+  windows: Monitor,
+  linuxAppImage: Terminal,
+  apk32: Cpu,
 };
-
-// Download targets. The stable-named desktop assets resolve through GitHub's
-// `/releases/latest/download/<asset>` redirect, so these URLs never need a
-// version bump. The APKs have version-stamped filenames, so the 32-bit build
-// links to the releases page rather than a direct asset.
-const RELEASES = "https://github.com/jcalado/voxdmr-site/releases";
-const DOWNLOADS: DownloadItem[] = [
-  {
-    key: "playStore",
-    labelKey: "download.playStore",
-    href: "https://play.google.com/store/apps/details?id=com.jcalado.voxdmr",
-    Icon: Smartphone,
-    external: true,
-  },
-  {
-    key: "windows",
-    labelKey: "download.windows",
-    href: `${RELEASES}/latest/download/VoxDMR-windows-x86_64.exe`,
-    Icon: Monitor,
-  },
-  {
-    key: "linuxAppImage",
-    labelKey: "download.linuxAppImage",
-    href: `${RELEASES}/latest/download/VoxDMR-linux-x86_64.AppImage`,
-    Icon: Terminal,
-  },
-  {
-    key: "apk32",
-    labelKey: "download.apk32",
-    href: `${RELEASES}/latest`,
-    Icon: Cpu,
-    external: true,
-  },
-];
 
 type DownloadMenuProps = {
   lang: Lang;
@@ -135,19 +100,22 @@ export default function DownloadMenu({
             style={{ top: coords.top, left: coords.left, width: MENU_WIDTH }}
             className="fixed z-[60] origin-top rounded-2xl border border-border bg-slate-900/95 p-2 shadow-2xl shadow-black/50 backdrop-blur-xl"
           >
-            {DOWNLOADS.map(({ key, labelKey, href, Icon, external }) => (
-              <a
-                key={key}
-                href={href}
-                role="menuitem"
-                onClick={() => setOpen(false)}
-                {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-                className="flex items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-semibold text-on-surface transition-colors hover:bg-white/10 hover:text-white"
-              >
-                <Icon className="w-4 h-4 shrink-0 text-vibrant-blue" />
-                {t(labelKey)}
-              </a>
-            ))}
+            {downloads.map(({ key, labelKey, href, external }) => {
+              const Icon = ICONS[key];
+              return (
+                <a
+                  key={key}
+                  href={href}
+                  role="menuitem"
+                  onClick={() => setOpen(false)}
+                  {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                  className="flex items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-semibold text-on-surface transition-colors hover:bg-white/10 hover:text-white"
+                >
+                  <Icon className="w-4 h-4 shrink-0 text-vibrant-blue" />
+                  {t(labelKey)}
+                </a>
+              );
+            })}
           </div>,
           document.body,
         )}


### PR DESCRIPTION
Follow-up to #157. Two things: the mobile slide-out never got the download treatment, and the switch left seven i18n keys stranded.

## Mobile nav

The slide-out's red CTA linked to `/#download` — the landing page's CTA section. From `/docs` or `/radios` that meant a full page navigation *away from where you were* just to reach a link.

It now lists the real targets inline:

```
        DOWNLOAD
  ┌──────────────────────┐
  │      Play Store      │   ← primary, red
  └──────────────────────┘
   Windows · Linux · APK     ← secondary links
```

Inline rather than nesting the `DownloadMenu` dropdown inside the slide-out: one tap instead of two, and no overlay stacked on an overlay. The Play Store leads because this menu only ever renders on a phone. Every entry carries `data-nav-link`, so the existing tap handler closes the menu — no new JS.

## Shared list

The four targets move to `src/downloads.ts`, imported by both the island and the nav, so they can't drift. `DownloadMenu` keeps the `key → LucideIcon` map, which is the only part that needs React; the `.astro` side renders text links and pulls in no runtime.

## Dead keys

Removed, all seven with zero call sites after #157:

`nav.getApp`, `cta.android`, `cta.desktop`, `cta.onPhone`, `cta.onDesktop`, `cta.getAndroid`, `cta.getDesktop`

`cta.community`, `cta.donate`, `cta.heading`, `cta.description`, `cta.setupGuide` and `cta.joinCommunity` are all still in use and untouched. Both locales end at 248 keys with no diff between their key sets.

`npm run lint` and `npm run build` pass; mobile block verified rendering in both `/` and `/pt/`.