### PR TITLE
Accessibility audit: contrast, keyboard access, landmarks, and a regression suite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,15 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # The build resolves the download links against the latest release's
+      # assets (src/lib/release.ts). Unauthenticated GitHub allows 60 requests
+      # per hour per IP and runners share IPs, so pass the token the job
+      # already has — `contents: read` above is enough to read releases.
+      # Without it the build still succeeds, but falls back to the static URLs
+      # in src/downloads.ts and loses the direct APK link.
       - run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-pages-artifact@v5
         with:
           path: dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ VoxDMR is a landing and documentation site for VoxDMR — a cross-platform app t
 - `npm run build` — Static production build to `dist/`, then `pagefind --site dist` to emit the search index into `dist/pagefind/`
 - `npm run preview` — Serve the built `dist/` locally
 - `npm run lint` — `astro check` + `tsc --noEmit` (no ESLint)
+- `npm run test:a11y` — axe-core over the **built** `dist/` (run `npm run build` first) across 11 pages in both locales; exits non-zero on any violation. Needs a Chromium once (`npx playwright install chromium`, or `CHROME_PATH=/usr/bin/chromium npm run test:a11y`).
 - `npm run clean` — Remove `dist/`
 
 ## Architecture
@@ -84,6 +85,20 @@ Uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (not PostCSS). Custom t
 - Fonts: `font-sans` (Inter), `font-headline` (Poppins)
 - Key colors: `vibrant-red` (#EF4444, primary accent), `vibrant-orange` (#FB923C, secondary), `vibrant-blue` (#38BDF8, tertiary), `community-bg` (#020617), `background` (#0F172A), `surface-raised` (#1E293B)
 - Custom utility: `.soft-shadow`
+
+**`vibrant-red` is for red *text* on a dark ground, never for a red fill behind white text** — white on #EF4444 is 3.76:1, under the AA floor. Filled buttons and active pills use `bg-red-cta` (#DC2626) with `hover:bg-red-cta-hover` (#B91C1C). Note `vibrant-red` itself only passes on `community-bg` (5.36:1) and `background` (4.74:1); on `surface-raised` it is 3.89:1, so red text there needs `red-400` instead.
+
+## Accessibility
+
+`npm run test:a11y` gates this — keep it at zero violations. Conventions worth knowing before adding UI:
+
+- **Focus.** `src/index.css` defines a site-wide `:focus-visible` outline. Only add `focus:outline-none` to a control if you are replacing it with a `focus-visible:ring-*` of your own; never to remove the indicator.
+- **Landmarks.** Every page's main region needs `id="main-content"` — the skip link in `Layout.astro` targets it on every route. Don't wrap a labelled `<nav>` in an `<aside>`; that adds a second, unnamed landmark.
+- **Localized ARIA.** `aria-label` and other announced strings come from `src/i18n/*.json` (the `a11y.*` keys), never hardcoded English — the site ships in two locales.
+- **New tabs.** Links with `target="_blank"` carry `<span class="sr-only"> ({t("a11y.newTab")})</span>`.
+- **Colour is never the only signal.** Links inside body copy are underlined, not just tinted; active states pair colour with `aria-current` or `aria-pressed`.
+- **Modals and menus** move focus in, trap Tab, and restore focus to whatever opened them. The docs search and image lightbox use a native `<dialog>` + `showModal()` so the platform does this; `ScreenshotGallery` and `DownloadMenu` do it by hand.
+- **No-JS.** `.scroll-reveal` starts at `opacity: 0`, so a `<noscript>` block in `Layout.astro`'s head neutralises it. Don't add a reveal mechanism without a matching fallback.
 
 ## Dependencies of Note
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ VoxDMR is a landing and documentation site for VoxDMR — a cross-platform app t
 - `npm run build` — Static production build to `dist/`, then `pagefind --site dist` to emit the search index into `dist/pagefind/`
 - `npm run preview` — Serve the built `dist/` locally
 - `npm run lint` — `astro check` + `tsc --noEmit` (no ESLint)
-- `npm run test:a11y` — axe-core over the **built** `dist/` (run `npm run build` first) across 11 pages in both locales; exits non-zero on any violation. Needs a Chromium once (`npx playwright install chromium`, or `CHROME_PATH=/usr/bin/chromium npm run test:a11y`).
+- `npm run test:a11y` — axe-core over the **built** `dist/` (run `npm run build` first): 11 pages in both locales at 1280 and 390, plus 5 opened states (search dialog, download menu, lightbox, mobile nav, docs drawer). Exits non-zero on any violation. Needs a Chromium once (`npx playwright install chromium`, or `CHROME_PATH=/usr/bin/chromium npm run test:a11y`).
 - `npm run clean` — Remove `dist/`
 
 ## Architecture
@@ -98,7 +98,8 @@ Uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (not PostCSS). Custom t
 - **New tabs.** Links with `target="_blank"` carry `<span class="sr-only"> ({t("a11y.newTab")})</span>`.
 - **Colour is never the only signal.** Links inside body copy are underlined, not just tinted; active states pair colour with `aria-current` or `aria-pressed`.
 - **Modals and menus** move focus in, trap Tab, and restore focus to whatever opened them. The docs search and image lightbox use a native `<dialog>` + `showModal()` so the platform does this; `ScreenshotGallery` and `DownloadMenu` do it by hand.
-- **No-JS.** `.scroll-reveal` starts at `opacity: 0`, so a `<noscript>` block in `Layout.astro`'s head neutralises it. Don't add a reveal mechanism without a matching fallback.
+- **No-JS.** `.scroll-reveal` starts at `opacity: 0`, and motion islands server-render an inline `style="opacity:0"`. A `<noscript>` block in `Layout.astro`'s head neutralises both. Don't add a reveal mechanism without a matching fallback — with JS off, `/radios` otherwise renders 22 invisible cards.
+- **Entrance animations hide content from axe.** axe does not evaluate text at `opacity: 0` — it neither passes nor flags it. The suite therefore scrolls each page to fire every reveal and then *fails* the page if any text is still invisible, because a clean result on faded-out content means nothing. If you add an entrance animation, make sure it settles under `prefers-reduced-motion`.
 
 ## Dependencies of Note
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (not PostCSS). Custom t
 
 - Resolving in the browser is deliberately avoided: unauthenticated GitHub is 60 req/hour **per IP**, so one NAT'd office would break the links for everyone behind it, and it would make downloads depend on JS.
 - **A new release does not reach the site until the site rebuilds.**
+- The build sends `GITHUB_TOKEN` (or `GH_TOKEN`) if set — the deploy workflow passes the one it already has. Unauthenticated is 60 req/hour **per IP** and CI runners share IPs; authenticated is 5000. Without it the build still succeeds but silently falls back. The build log says which mode it used.
 - API unreachable → warn, fall back, build succeeds. API answers but a pattern matches nothing (an asset was renamed) → **the production build fails**, rather than shipping links that 404. Update `ASSET_PATTERNS` in `release.ts` when release filenames change.
 - `Download` objects are serialized into the `DownloadMenu` island's props, so they must stay JSON-safe — the matching RegExps live in `release.ts`, not on the type.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,15 @@ Uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (not PostCSS). Custom t
 
 **`vibrant-red` is for red *text* on a dark ground, never for a red fill behind white text** — white on #EF4444 is 3.76:1, under the AA floor. Filled buttons and active pills use `bg-red-cta` (#DC2626) with `hover:bg-red-cta-hover` (#B91C1C). Note `vibrant-red` itself only passes on `community-bg` (5.36:1) and `background` (4.74:1); on `surface-raised` it is 3.89:1, so red text there needs `red-400` instead.
 
+## Download links
+
+`src/downloads.ts` holds the target list; `src/lib/release.ts` resolves each one against the **actual assets of the latest GitHub release at build time** (one fetch per build, memoized) and that is what the pages render. `src/downloads.ts` is only the fallback for an unreachable API.
+
+- Resolving in the browser is deliberately avoided: unauthenticated GitHub is 60 req/hour **per IP**, so one NAT'd office would break the links for everyone behind it, and it would make downloads depend on JS.
+- **A new release does not reach the site until the site rebuilds.**
+- API unreachable → warn, fall back, build succeeds. API answers but a pattern matches nothing (an asset was renamed) → **the production build fails**, rather than shipping links that 404. Update `ASSET_PATTERNS` in `release.ts` when release filenames change.
+- `Download` objects are serialized into the `DownloadMenu` island's props, so they must stay JSON-safe — the matching RegExps live in `release.ts`, not on the type.
+
 ## Accessibility
 
 `npm run test:a11y` gates this — keep it at zero violations. Conventions worth knowing before adding UI:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import remarkDirective from 'remark-directive';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { remarkPlatform } from './src/lib/remark-platform.ts';
+import { rehypeAnchorLabel } from './src/lib/rehype-anchor-label.ts';
 
 // lucide `link` icon as hast, prepended to h2+ as a hover-revealed permalink
 // (styled by `.heading-anchor` in docs.css).
@@ -39,6 +40,10 @@ export default defineConfig({
   // platform directives (remark-directive + remark-platform) and heading
   // anchors keep working.
   markdown: {
+    // The default `github-dark` renders comments at #6a737d on #24292e —
+    // 3.04:1, under the AA floor, which put every code comment in the docs
+    // below the threshold. Same family, palette that clears it.
+    shikiConfig: { theme: 'github-dark-default' },
     processor: unified({
       remarkPlugins: [remarkDirective, remarkPlatform],
       rehypePlugins: [
@@ -51,12 +56,15 @@ export default defineConfig({
             test: ['h2', 'h3', 'h4', 'h5', 'h6'],
             properties: {
               className: ['heading-anchor'],
-              'aria-label': 'Permalink to this section',
               tabindex: -1,
             },
             content: anchorIcon,
           },
         ],
+        // The label above is static config, so it cannot vary by locale;
+        // this rewrites it per the file's language (it was announcing the
+        // English string on the Portuguese docs).
+        rehypeAnchorLabel,
       ],
     }),
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,9 @@
         "@types/node": "^22.14.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "axe-core": "^4.13.0",
         "pagefind": "^1.5.2",
+        "playwright": "^1.63.0",
         "tailwindcss": "^4.1.14",
         "typescript": "~5.8.2"
       }
@@ -3217,6 +3219,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -5993,6 +6005,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build && pagefind --site dist",
     "preview": "astro preview",
     "clean": "rm -rf dist",
-    "lint": "astro check && tsc --noEmit"
+    "lint": "astro check && tsc --noEmit",
+    "test:a11y": "node scripts/a11y.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",
@@ -34,7 +35,9 @@
     "@types/node": "^22.14.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "axe-core": "^4.13.0",
     "pagefind": "^1.5.2",
+    "playwright": "^1.63.0",
     "tailwindcss": "^4.1.14",
     "typescript": "~5.8.2"
   },

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1,0 +1,130 @@
+/**
+ * Accessibility regression check: runs axe-core over the built site in both
+ * locales and exits non-zero on any violation.
+ *
+ *   npm run build && npm run test:a11y
+ *
+ * Needs a Chromium once: `npx playwright install chromium`, or point
+ * CHROME_PATH at an existing one (e.g. CHROME_PATH=/usr/bin/chromium).
+ *
+ * The site is static, so this serves `dist/` directly rather than booting the
+ * dev server — the dev server does not have the Pagefind bundle, and the docs
+ * search modal behaves differently without it.
+ */
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { extname, join, normalize } from "node:path";
+import { chromium } from "playwright";
+
+const DIST = new URL("../dist/", import.meta.url).pathname;
+const PORT = 4399;
+
+/** Pages worth checking: one of each template, in both locales. */
+const PAGES = [
+  "/",
+  "/radios",
+  "/privacy",
+  "/brandmeister-password",
+  "/docs/installation",
+  "/docs/changelog",
+  "/pt/",
+  "/pt/radios",
+  "/pt/privacy",
+  "/pt/brandmeister-password",
+  "/pt/docs/installation",
+];
+
+const TYPES = {
+  ".html": "text/html", ".css": "text/css", ".js": "text/javascript",
+  ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png",
+  ".jpg": "image/jpeg", ".webp": "image/webp", ".ico": "image/x-icon",
+  ".woff": "font/woff", ".woff2": "font/woff2", ".wasm": "application/wasm",
+  ".pf_meta": "application/octet-stream", ".pf_fragment": "application/octet-stream",
+  ".pf_index": "application/octet-stream",
+};
+
+/** Minimal static file server. No SPA fallback — a wrong URL must 404, not
+    silently serve index.html and make every page look identical. */
+function serve() {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const url = decodeURIComponent(req.url.split("?")[0]);
+      let path = normalize(join(DIST, url));
+      if (!path.startsWith(DIST)) return res.writeHead(403).end();
+      if (existsSync(path) && statSync(path).isDirectory()) path = join(path, "index.html");
+      if (!existsSync(path)) {
+        if (existsSync(`${path}.html`)) path = `${path}.html`;
+        else return res.writeHead(404).end("not found");
+      }
+      res.writeHead(200, { "content-type": TYPES[extname(path)] ?? "application/octet-stream" });
+      createReadStream(path).pipe(res);
+    });
+    server.listen(PORT, () => resolve(server));
+  });
+}
+
+const axeSource = await readFile(
+  new URL("../node_modules/axe-core/axe.min.js", import.meta.url),
+  "utf8",
+);
+
+const server = await serve();
+const browser = await chromium.launch(
+  process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {},
+);
+let total = 0;
+
+for (const path of PAGES) {
+  const page = await browser.newPage({
+    viewport: { width: 1280, height: 900 },
+    // Settle the entrance animations rather than racing them: axe reads
+    // computed colour, and a half-faded element composites to a contrast
+    // ratio that has nothing to do with the design.
+    reducedMotion: "reduce",
+  });
+  const res = await page.goto(`http://localhost:${PORT}${path}`, { waitUntil: "networkidle" });
+  if (!res || res.status() !== 200) {
+    console.error(`✗ ${path} — HTTP ${res?.status()}`);
+    total++;
+    await page.close();
+    continue;
+  }
+
+  // Scroll the whole page so every IntersectionObserver-driven reveal fires.
+  await page.evaluate(() => {
+    for (let y = 0; y < document.body.scrollHeight; y += 400) window.scrollTo(0, y);
+    window.scrollTo(0, 0);
+  });
+  await page.waitForTimeout(600);
+
+  await page.addScriptTag({ content: axeSource });
+  const { violations } = await page.evaluate(() =>
+    window.axe.run(document, {
+      runOnly: { type: "tag", values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"] },
+    }),
+  );
+
+  total += violations.length;
+  if (violations.length === 0) {
+    console.log(`✓ ${path}`);
+  } else {
+    console.log(`✗ ${path} — ${violations.length} violation(s)`);
+    for (const v of violations) {
+      console.log(`    [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`);
+      for (const n of v.nodes.slice(0, 5)) console.log(`        ${n.target.join(" ")}`);
+      console.log(`        ${v.helpUrl}`);
+    }
+  }
+  await page.close();
+}
+
+await browser.close();
+server.close();
+
+console.log(
+  total === 0
+    ? `\nNo accessibility violations across ${PAGES.length} pages.`
+    : `\n${total} violation(s) across ${PAGES.length} pages.`,
+);
+process.exit(total === 0 ? 0 : 1);

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -49,7 +49,14 @@ const TYPES = {
 function serve() {
   return new Promise((resolve) => {
     const server = createServer((req, res) => {
-      const url = decodeURIComponent(req.url.split("?")[0]);
+      let url;
+      try {
+        url = decodeURIComponent(req.url.split("?")[0]);
+      } catch {
+        // Malformed percent-encoding would otherwise throw out of the request
+        // handler and take the whole process down mid-run.
+        return res.writeHead(400).end("bad request");
+      }
       let path = normalize(join(DIST, url));
       if (!path.startsWith(DIST)) return res.writeHead(403).end();
       if (existsSync(path) && statSync(path).isDirectory()) path = join(path, "index.html");
@@ -69,53 +76,210 @@ const axeSource = await readFile(
   "utf8",
 );
 
+const TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"];
+
+/** Desktop and a small phone — the narrow pass is what catches reflow. */
+const VIEWPORTS = [
+  { name: "1280", width: 1280, height: 900 },
+  { name: "390", width: 390, height: 800 },
+];
+
+/**
+ * Entrance animations start elements at opacity 0. axe does not evaluate
+ * invisible text *at all* — it neither passes nor flags it — so anything still
+ * faded out when axe runs is silently exempt from the whole audit. Scroll the
+ * page in steps, yielding to the event loop between them so the
+ * IntersectionObserver actually fires (a synchronous loop only ever reports the
+ * final position), then let the transitions finish.
+ */
+async function settleReveals(page) {
+  await page.evaluate(async () => {
+    const wait = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    for (let y = 0; y < document.body.scrollHeight; y += 400) {
+      window.scrollTo(0, y);
+      await wait();
+    }
+    window.scrollTo(0, 0);
+    await wait();
+  });
+  await page.waitForTimeout(800);
+}
+
+/**
+ * Guards the above: reports any element that still carries text nobody can see.
+ * Deliberately-hidden things (display:none, visibility:hidden, hover tooltips)
+ * are excluded; so are descendants of an already-reported element.
+ */
+async function invisibleText(page) {
+  return page.evaluate(() => {
+    const faded = (el) => {
+      const s = getComputedStyle(el);
+      return (
+        parseFloat(s.opacity) <= 0.01 &&
+        s.visibility !== "hidden" &&
+        s.display !== "none" &&
+        !el.closest('[role="tooltip"]')
+      );
+    };
+    return Array.from(document.querySelectorAll("body *"))
+      .filter((el) => (el.textContent || "").trim() && faded(el))
+      // Only the outermost offender — a faded container fades its whole subtree.
+      .filter((el) => !(el.parentElement && faded(el.parentElement)))
+      .map((el) => `${el.tagName.toLowerCase()}.${String(el.className).trim().slice(0, 48)}`);
+  });
+}
+
+async function runAxe(page, options = {}) {
+  await page.addScriptTag({ content: axeSource });
+  const { violations } = await page.evaluate(
+    ([tags, disabled]) =>
+      window.axe.run(document, {
+        runOnly: { type: "tag", values: tags },
+        rules: Object.fromEntries(disabled.map((id) => [id, { enabled: false }])),
+      }),
+    [TAGS, options.disableRules ?? []],
+  );
+  return violations;
+}
+
+function report(label, violations) {
+  if (violations.length === 0) {
+    console.log(`✓ ${label}`);
+    return 0;
+  }
+  console.log(`✗ ${label} — ${violations.length} violation(s)`);
+  for (const v of violations) {
+    console.log(`    [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`);
+    for (const n of v.nodes.slice(0, 5)) console.log(`        ${n.target.join(" ")}`);
+    console.log(`        ${v.helpUrl}`);
+  }
+  return violations.length;
+}
+
+/**
+ * Opened menus, dialogs and drawers — the states the static pass never sees,
+ * and where most of the keyboard and focus behaviour actually lives.
+ */
+const STATES = [
+  {
+    label: "docs search dialog (open, with results)",
+    path: "/docs/installation",
+    async setup(page) {
+      await page.click("[data-search-open]");
+      await page.fill("[data-search-input]", "install");
+      await page.waitForFunction(() => document.querySelectorAll(".docs-search-hit").length > 0);
+    },
+  },
+  {
+    label: "download menu (open)",
+    path: "/",
+    async setup(page) {
+      await page.click('nav button[aria-haspopup="menu"]');
+      await page.waitForSelector('[role="menu"]');
+    },
+    // The menu is portalled to <body> so no `backdrop-filter` ancestor clips
+    // it, which necessarily puts it outside every landmark. `region` is a
+    // best-practice rule, not a WCAG one, and the alternative (a landmark
+    // wrapping a transient dropdown) is worse for the reader.
+    disableRules: ["region"],
+  },
+  {
+    label: "docs image lightbox (open)",
+    path: "/docs/installation",
+    async setup(page) {
+      // `:visible` matters: the first content image may sit inside a
+      // :::mobile block, which the desktop platform filter hides.
+      await page.locator(".doc-zoom-btn:visible").first().click();
+      await page.waitForFunction(() => document.querySelector("[data-doc-lightbox]")?.open);
+    },
+  },
+  {
+    label: "mobile nav menu (open)",
+    path: "/",
+    viewport: { width: 390, height: 800 },
+    async setup(page) {
+      await page.click("[data-nav-toggle]");
+      await page.waitForTimeout(400);
+    },
+  },
+  {
+    label: "docs sidebar drawer (open)",
+    path: "/docs/installation",
+    viewport: { width: 390, height: 800 },
+    async setup(page) {
+      await page.click("[data-sidebar-toggle]");
+      await page.waitForTimeout(400);
+    },
+  },
+];
+
 const server = await serve();
 const browser = await chromium.launch(
   process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {},
 );
 let total = 0;
+let checks = 0;
 
-for (const path of PAGES) {
-  const page = await browser.newPage({
-    viewport: { width: 1280, height: 900 },
-    // Settle the entrance animations rather than racing them: axe reads
-    // computed colour, and a half-faded element composites to a contrast
-    // ratio that has nothing to do with the design.
-    reducedMotion: "reduce",
-  });
+async function open(viewport, path) {
+  const page = await browser.newPage({ viewport, reducedMotion: "reduce" });
   const res = await page.goto(`http://localhost:${PORT}${path}`, { waitUntil: "networkidle" });
   if (!res || res.status() !== 200) {
-    console.error(`✗ ${path} — HTTP ${res?.status()}`);
+    await page.close();
+    return { page: null, status: res?.status() };
+  }
+  return { page, status: 200 };
+}
+
+for (const viewport of VIEWPORTS) {
+  for (const path of PAGES) {
+    const label = `${path} @${viewport.name}`;
+    checks++;
+    const { page, status } = await open(viewport, path);
+    if (!page) {
+      console.log(`✗ ${label} — HTTP ${status}`);
+      total++;
+      continue;
+    }
+
+    await settleReveals(page);
+    const hidden = await invisibleText(page);
+    if (hidden.length) {
+      // Not a violation in itself — it means axe was about to skip this
+      // content, so a clean result here would be meaningless.
+      console.log(`✗ ${label} — ${hidden.length} element(s) still invisible; axe would skip them`);
+      for (const h of hidden.slice(0, 5)) console.log(`        ${h}`);
+      total++;
+      await page.close();
+      continue;
+    }
+
+    total += report(label, await runAxe(page));
+    await page.close();
+  }
+}
+
+for (const state of STATES) {
+  const viewport = state.viewport ?? VIEWPORTS[0];
+  const label = `${state.path} — ${state.label}`;
+  checks++;
+  const { page, status } = await open(viewport, state.path);
+  if (!page) {
+    console.log(`✗ ${label} — HTTP ${status}`);
+    total++;
+    continue;
+  }
+  await settleReveals(page);
+  try {
+    await state.setup(page);
+  } catch (err) {
+    // A state that can no longer be reached is itself the finding — report it
+    // rather than letting the timeout take the whole run down.
+    console.log(`✗ ${label} — could not reach this state: ${err.message.split("\n")[0]}`);
     total++;
     await page.close();
     continue;
   }
-
-  // Scroll the whole page so every IntersectionObserver-driven reveal fires.
-  await page.evaluate(() => {
-    for (let y = 0; y < document.body.scrollHeight; y += 400) window.scrollTo(0, y);
-    window.scrollTo(0, 0);
-  });
-  await page.waitForTimeout(600);
-
-  await page.addScriptTag({ content: axeSource });
-  const { violations } = await page.evaluate(() =>
-    window.axe.run(document, {
-      runOnly: { type: "tag", values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"] },
-    }),
-  );
-
-  total += violations.length;
-  if (violations.length === 0) {
-    console.log(`✓ ${path}`);
-  } else {
-    console.log(`✗ ${path} — ${violations.length} violation(s)`);
-    for (const v of violations) {
-      console.log(`    [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`);
-      for (const n of v.nodes.slice(0, 5)) console.log(`        ${n.target.join(" ")}`);
-      console.log(`        ${v.helpUrl}`);
-    }
-  }
+  total += report(label, await runAxe(page, { disableRules: state.disableRules }));
   await page.close();
 }
 
@@ -124,7 +288,7 @@ server.close();
 
 console.log(
   total === 0
-    ? `\nNo accessibility violations across ${PAGES.length} pages.`
-    : `\n${total} violation(s) across ${PAGES.length} pages.`,
+    ? `\nNo accessibility violations across ${checks} checks.`
+    : `\n${total} violation(s) across ${checks} checks.`,
 );
 process.exit(total === 0 ? 0 : 1);

--- a/src/components/CtaBar.astro
+++ b/src/components/CtaBar.astro
@@ -26,7 +26,7 @@ const t = getT(lang);
   <DownloadMenu
     lang={lang}
     className="col-span-2 sm:col-span-1"
-    triggerClassName={`${SEGMENT} w-full sm:w-auto bg-vibrant-red hover:bg-red-500 text-white font-bold`}
+    triggerClassName={`${SEGMENT} w-full sm:w-auto bg-red-cta hover:bg-red-cta-hover text-white font-bold`}
     client:load
   />
   <a href={TELEGRAM_URL} target="_blank" rel="noopener noreferrer" class={`${SEGMENT} bg-white/5 hover:bg-white/10 text-on-surface font-semibold`}>

--- a/src/components/CtaBar.astro
+++ b/src/components/CtaBar.astro
@@ -3,6 +3,7 @@ import MessageCircle from "@/src/components/icons/MessageCircle.astro";
 import Coffee from "@/src/components/icons/Coffee.astro";
 import DownloadMenu from "@/src/islands/DownloadMenu.tsx";
 import { getT, type Lang } from "@/src/i18n/t";
+import { resolveDownloads } from "@/src/lib/release";
 
 const TELEGRAM_URL = "https://t.me/+6-ncS_eluTUxNmU0";
 const KOFI_URL = "https://ko-fi.com/jcalado";
@@ -19,12 +20,14 @@ interface Props {
 
 const { lang, className = "" } = Astro.props;
 const t = getT(lang);
+const downloads = await resolveDownloads();
 ---
 <div
   class={`grid w-full grid-cols-2 gap-1.5 rounded-3xl border border-border bg-surface-raised/40 p-1.5 sm:inline-flex sm:w-auto sm:flex-wrap sm:items-center sm:gap-1.5 sm:rounded-full ${className}`}
 >
   <DownloadMenu
     lang={lang}
+    downloads={downloads}
     className="col-span-2 sm:col-span-1"
     triggerClassName={`${SEGMENT} w-full sm:w-auto bg-red-cta hover:bg-red-cta-hover text-white font-bold`}
     client:load

--- a/src/components/CtaBar.astro
+++ b/src/components/CtaBar.astro
@@ -32,9 +32,11 @@ const t = getT(lang);
   <a href={TELEGRAM_URL} target="_blank" rel="noopener noreferrer" class={`${SEGMENT} bg-white/5 hover:bg-white/10 text-on-surface font-semibold`}>
     <MessageCircle class="w-5 h-5" />
     {t("cta.community")}
+    <span class="sr-only"> ({t("a11y.newTab")})</span>
   </a>
   <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" class={`${SEGMENT} bg-vibrant-orange/15 hover:bg-vibrant-orange/25 text-vibrant-orange font-semibold`}>
     <Coffee class="w-5 h-5" />
     {t("cta.donate")}
+    <span class="sr-only"> ({t("a11y.newTab")})</span>
   </a>
 </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -34,7 +34,7 @@ const [copyBefore, copyAfter] = t("footer.copyright").split("{callsign}");
       <span class="font-bold font-headline text-white text-2xl tracking-tight">VoxDMR</span>
     </div>
 
-    <div class="flex flex-wrap justify-center gap-6 lg:gap-10">
+    <nav class="flex flex-wrap justify-center gap-6 lg:gap-10" aria-label={t("a11y.footerNav")}>
       {links.map((link) => (
         <a
           class="text-sm font-semibold text-on-surface-muted hover:text-vibrant-red transition-colors"
@@ -44,7 +44,7 @@ const [copyBefore, copyAfter] = t("footer.copyright").split("{callsign}");
           {link.label}
         </a>
       ))}
-    </div>
+    </nav>
 
     <div class="text-on-surface-muted text-sm font-medium text-center md:text-right">
       {copyBefore}<a

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,6 +2,7 @@
 import Logo from "@/src/components/Logo.astro";
 import { getT, type Lang } from "@/src/i18n/t";
 import { localizePath } from "@/src/i18n/routing";
+import { downloads } from "@/src/downloads";
 
 interface Props {
   lang: Lang;
@@ -28,32 +29,69 @@ const callsign = "CT7BLE";
 const [copyBefore, copyAfter] = t("footer.copyright").split("{callsign}");
 ---
 <footer class="bg-slate-950 py-16 border-t border-border">
-  <div class="flex flex-col md:flex-row justify-between items-center px-6 lg:px-12 gap-10 max-w-7xl mx-auto">
-    <div class="flex items-center gap-4">
-      <Logo size="sm" />
-      <span class="font-bold font-headline text-white text-2xl tracking-tight">VoxDMR</span>
-    </div>
+  <div class="max-w-7xl mx-auto px-6 lg:px-12">
+    {/*
+      The download targets as plain links, not only inside the DownloadMenu
+      dropdown. Every "Download" affordance elsewhere on the site is a button
+      that reveals its targets on activation, so before this the four of them
+      were absent from a screen reader's links list — the fastest way most
+      screen reader users scan a page — and the only listed route to a download
+      was the GitHub link below, which lands on a releases page.
 
-    <nav class="flex flex-wrap justify-center gap-6 lg:gap-10" aria-label={t("a11y.footerNav")}>
-      {links.map((link) => (
-        <a
-          class="text-sm font-semibold text-on-surface-muted hover:text-vibrant-red transition-colors"
-          href={link.href}
-          {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-        >
-          {link.label}
-          {link.external && <span class="sr-only"> ({t("a11y.newTab")})</span>}
-        </a>
-      ))}
+      A labelled <nav> so it is also reachable by landmark navigation, and
+      driven by the same `downloads` array as the menu so the two can't drift.
+    */}
+    <nav
+      class="flex flex-col items-center gap-4 border-b border-border pb-10 sm:flex-row sm:justify-center sm:gap-8"
+      aria-labelledby="footer-download-label"
+    >
+      <span
+        id="footer-download-label"
+        class="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-on-surface-muted"
+      >
+        {t("download.label")}
+      </span>
+      <div class="flex flex-wrap justify-center gap-x-6 gap-y-3">
+        {downloads.map((d) => (
+          <a
+            href={d.href}
+            {...(d.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+            class="text-sm font-semibold text-on-surface hover:text-vibrant-red transition-colors"
+          >
+            {t(d.labelKey)}
+            {d.external && <span class="sr-only"> ({t("a11y.newTab")})</span>}
+          </a>
+        ))}
+      </div>
     </nav>
 
-    <div class="text-on-surface-muted text-sm font-medium text-center md:text-right">
-      {copyBefore}<a
-        href={`https://www.qrz.com/db/${callsign}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-white font-semibold hover:text-vibrant-red transition-colors"
-      >{callsign}<span class="sr-only"> ({t("a11y.newTab")})</span></a>{copyAfter}
+    <div class="flex flex-col md:flex-row justify-between items-center gap-10 pt-10">
+      <div class="flex items-center gap-4">
+        <Logo size="sm" />
+        <span class="font-bold font-headline text-white text-2xl tracking-tight">VoxDMR</span>
+      </div>
+
+      <nav class="flex flex-wrap justify-center gap-6 lg:gap-10" aria-label={t("a11y.footerNav")}>
+        {links.map((link) => (
+          <a
+            class="text-sm font-semibold text-on-surface-muted hover:text-vibrant-red transition-colors"
+            href={link.href}
+            {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+          >
+            {link.label}
+            {link.external && <span class="sr-only"> ({t("a11y.newTab")})</span>}
+          </a>
+        ))}
+      </nav>
+
+      <div class="text-on-surface-muted text-sm font-medium text-center md:text-right">
+        {copyBefore}<a
+          href={`https://www.qrz.com/db/${callsign}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-white font-semibold hover:text-vibrant-red transition-colors"
+        >{callsign}<span class="sr-only"> ({t("a11y.newTab")})</span></a>{copyAfter}
+      </div>
     </div>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,6 +42,7 @@ const [copyBefore, copyAfter] = t("footer.copyright").split("{callsign}");
           {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
         >
           {link.label}
+          {link.external && <span class="sr-only"> ({t("a11y.newTab")})</span>}
         </a>
       ))}
     </nav>
@@ -52,7 +53,7 @@ const [copyBefore, copyAfter] = t("footer.copyright").split("{callsign}");
         target="_blank"
         rel="noopener noreferrer"
         class="text-white font-semibold hover:text-vibrant-red transition-colors"
-      >{callsign}</a>{copyAfter}
+      >{callsign}<span class="sr-only"> ({t("a11y.newTab")})</span></a>{copyAfter}
     </div>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 import Logo from "@/src/components/Logo.astro";
 import { getT, type Lang } from "@/src/i18n/t";
 import { localizePath } from "@/src/i18n/routing";
-import { downloads } from "@/src/downloads";
+import { resolveDownloads } from "@/src/lib/release";
 
 interface Props {
   lang: Lang;
@@ -10,6 +10,8 @@ interface Props {
 
 const { lang } = Astro.props;
 const t = getT(lang);
+
+const downloads = await resolveDownloads();
 
 const docsHref = localizePath("/docs", lang);
 const radiosHref = localizePath("/radios", lang);

--- a/src/components/LandingBody.astro
+++ b/src/components/LandingBody.astro
@@ -21,31 +21,36 @@ const t = getT(lang);
 <div class="min-h-screen bg-community-bg text-on-surface font-sans selection:bg-vibrant-blue/20">
   <SiteNav lang={lang} pathname={localizePath("/", lang)} />
 
-  <HeroSection lang={lang} />
+  {/* The landing page had no <main>, so it offered no landmark to jump to and
+      nothing for the skip link to target. The hero is part of the content, so
+      it lives inside; only the nav and footer sit outside. */}
+  <main id="main-content">
+    <HeroSection lang={lang} />
 
-  <UseCases lang={lang} />
+    <UseCases lang={lang} />
 
-  {/* Screenshots Gallery */}
-  <section id="screenshots" class="py-16 lg:py-24 px-6 lg:px-8 scroll-mt-24">
-    <div class="max-w-7xl mx-auto">
-      <ScreenshotGallery lang={lang} client:visible />
-    </div>
-  </section>
-
-  <Features lang={lang} />
-
-  {/* FAQ */}
-  <section class="pt-20 lg:pt-28 pb-12 lg:pb-16 px-6 lg:px-8 bg-community-bg">
-    <div class="max-w-7xl mx-auto">
-      <div class="scroll-reveal mb-12">
-        <h2 class="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t("faq.heading")}</h2>
-        <p class="text-on-surface-muted text-lg leading-relaxed">{t("faq.subheading")}</p>
+    {/* Screenshots Gallery */}
+    <section id="screenshots" class="py-16 lg:py-24 px-6 lg:px-8 scroll-mt-24" aria-labelledby="screenshots-heading">
+      <div class="max-w-7xl mx-auto">
+        <ScreenshotGallery lang={lang} client:visible />
       </div>
-      <FaqAccordion lang={lang} client:visible />
-    </div>
-  </section>
+    </section>
 
-  <CtaSection lang={lang} />
+    <Features lang={lang} />
+
+    {/* FAQ */}
+    <section class="pt-20 lg:pt-28 pb-12 lg:pb-16 px-6 lg:px-8 bg-community-bg" aria-labelledby="faq-heading">
+      <div class="max-w-7xl mx-auto">
+        <div class="scroll-reveal mb-12">
+          <h2 id="faq-heading" class="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t("faq.heading")}</h2>
+          <p class="text-on-surface-muted text-lg leading-relaxed">{t("faq.subheading")}</p>
+        </div>
+        <FaqAccordion lang={lang} client:visible />
+      </div>
+    </section>
+
+    <CtaSection lang={lang} />
+  </main>
 
   <Footer lang={lang} />
 

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -10,10 +10,16 @@ interface Props {
 
 const { lang, pathname } = Astro.props;
 const href = altLocalePath(pathname);
+
+// The label is deliberately written in the language being switched *to*, so the
+// anchor declares that language — otherwise a screen reader reads "Mudar para
+// Português" with an English voice.
+const labelLang = lang === "en" ? "pt" : "en";
 ---
 <a
   href={href}
   class="flex items-center gap-1.5 text-on-surface-muted hover:text-vibrant-red transition-colors px-2 py-1 rounded-lg"
+  lang={labelLang}
   aria-label={lang === "en" ? "Mudar para Português" : "Switch to English"}
 >
   <Globe class="w-4 h-4" />

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -10,11 +10,16 @@ const logoSizes = {
 interface Props {
   size?: keyof typeof logoSizes;
   className?: string;
+  /** Alt text. Defaults to empty: every current use sits beside a visible
+      "VoxDMR" wordmark inside the same link, where a described logo makes a
+      screen reader announce the name twice. Pass one only when the mark
+      stands alone. */
+  alt?: string;
 }
 
-const { size = "md", className = "" } = Astro.props;
+const { size = "md", className = "", alt = "" } = Astro.props;
 const s = logoSizes[size];
 ---
 <div class={`${s.container} bg-surface-raised overflow-hidden flex items-center justify-center ${className}`}>
-  <img alt="VoxDMR Logo" class={`${s.img} object-cover`} src={LOGO_URL} />
+  <img alt={alt} class={`${s.img} object-cover`} src={LOGO_URL} />
 </div>

--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -6,7 +6,7 @@ import Menu from "@/src/components/icons/Menu.astro";
 import X from "@/src/components/icons/X.astro";
 import { getT, type Lang } from "@/src/i18n/t";
 import { localizePath } from "@/src/i18n/routing";
-import { downloads } from "@/src/downloads";
+import { resolveDownloads } from "@/src/lib/release";
 
 const linkClass =
   "nav-link font-medium text-on-surface-muted hover:text-vibrant-red transition-colors px-2 py-1";
@@ -34,6 +34,9 @@ const navLinks = [
 const isCurrent = (href: string) =>
   !href.includes("#") && (pathname === href || pathname.startsWith(`${href}/`));
 
+// Resolved against the latest release's actual assets at build time.
+const downloads = await resolveDownloads();
+
 // The phone menu leads with the Play Store and demotes the rest.
 const primary = downloads.find((d) => d.key === "playStore")!;
 const secondary = downloads.filter((d) => d.key !== "playStore");
@@ -60,6 +63,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
       <LanguageSwitcher lang={lang} pathname={pathname} />
       <DownloadMenu
         lang={lang}
+        downloads={downloads}
         align="right"
         className="hidden lg:block"
         triggerClassName="btn-press inline-flex items-center gap-2 bg-red-cta hover:bg-red-cta-hover text-white px-5 lg:px-6 py-2.5 lg:py-3 rounded-2xl font-bold hover:scale-105 transition-all"

--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -49,7 +49,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
         lang={lang}
         align="right"
         className="hidden lg:block"
-        triggerClassName="btn-press inline-flex items-center gap-2 bg-vibrant-red hover:bg-red-500 text-white px-5 lg:px-6 py-2.5 lg:py-3 rounded-2xl font-bold hover:scale-105 transition-all"
+        triggerClassName="btn-press inline-flex items-center gap-2 bg-red-cta hover:bg-red-cta-hover text-white px-5 lg:px-6 py-2.5 lg:py-3 rounded-2xl font-bold hover:scale-105 transition-all"
         client:load
       />
       <button
@@ -100,7 +100,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
           data-nav-link
           target="_blank"
           rel="noopener noreferrer"
-          class="btn-press w-full bg-vibrant-red hover:bg-red-500 text-white text-center px-6 py-3 rounded-2xl font-bold transition-colors"
+          class="btn-press w-full bg-red-cta hover:bg-red-cta-hover text-white text-center px-6 py-3 rounded-2xl font-bold transition-colors"
         >
           {t(primary.labelKey)}
         </a>

--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -117,6 +117,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
           class="btn-press w-full bg-red-cta hover:bg-red-cta-hover text-white text-center px-6 py-3 rounded-2xl font-bold transition-colors"
         >
           {t(primary.labelKey)}
+          <span class="sr-only"> ({t("a11y.newTab")})</span>
         </a>
         <div class="flex flex-wrap justify-center gap-x-5 gap-y-2 pb-1">
           {secondary.map((d) => (
@@ -127,6 +128,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
               class="text-sm font-medium text-on-surface-muted hover:text-white transition-colors"
             >
               {t(d.labelKey)}
+              {d.external && <span class="sr-only"> ({t("a11y.newTab")})</span>}
             </a>
           ))}
         </div>

--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -28,11 +28,20 @@ const navLinks = [
   { href: localizePath("/radios", lang), label: t("nav.radios") },
 ];
 
+/** aria-current for the section the reader is in — the active link was marked
+    by colour alone, which says nothing to a screen reader. In-page anchors are
+    excluded: they point within the current page rather than away from it. */
+const isCurrent = (href: string) =>
+  !href.includes("#") && (pathname === href || pathname.startsWith(`${href}/`));
+
 // The phone menu leads with the Play Store and demotes the rest.
 const primary = downloads.find((d) => d.key === "playStore")!;
 const secondary = downloads.filter((d) => d.key !== "playStore");
 ---
-<nav class="w-full top-0 sticky z-50 bg-slate-950/80 backdrop-blur-xl h-24 flex items-center border-b border-border">
+<nav
+  class="w-full top-0 sticky z-50 bg-slate-950/80 backdrop-blur-xl h-24 flex items-center border-b border-border"
+  aria-label={t("a11y.primaryNav")}
+>
   <div class="flex justify-between items-center max-w-7xl mx-auto px-6 lg:px-10 w-full">
     <a href={home} class="flex items-center gap-4 lg:gap-5">
       <Logo size="md" className="shadow-lg shadow-black/40" />
@@ -40,7 +49,11 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
     </a>
 
     <div class="hidden lg:flex gap-12 items-center">
-      {navLinks.map((l) => <a class={linkClass} href={l.href}>{l.label}</a>)}
+      {navLinks.map((l) => (
+        <a class={linkClass} href={l.href} {...(isCurrent(l.href) ? { "aria-current": "page" } : {})}>
+          {l.label}
+        </a>
+      ))}
     </div>
 
     <div class="flex items-center gap-3 lg:gap-4">
@@ -56,7 +69,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
         type="button"
         class="lg:hidden text-on-surface-muted hover:text-white transition-colors p-1.5 -mr-1.5"
         data-nav-toggle
-        aria-label="Toggle menu"
+        aria-label={t("a11y.toggleMenu")}
         aria-expanded="false"
         aria-controls="site-mobile-menu"
       >
@@ -78,6 +91,7 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
         <a
           href={l.href}
           data-nav-link
+          {...(isCurrent(l.href) ? { "aria-current": "page" } : {})}
           class="text-on-surface-muted hover:text-white font-medium text-lg py-3 border-b border-border/60 last:border-0 transition-colors"
         >
           {l.label}
@@ -141,8 +155,11 @@ const secondary = downloads.filter((d) => d.key !== "playStore");
   document
     .querySelectorAll("[data-nav-link]")
     .forEach((a) => a.addEventListener("click", () => setOpen(false)));
-  // Close on Escape.
+  // Close on Escape, handing focus back to the button that opened the menu —
+  // otherwise focus is left inside a menu that is no longer visible.
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") setOpen(false);
+    if (e.key !== "Escape" || menu?.getAttribute("data-open") !== "true") return;
+    setOpen(false);
+    (toggle as HTMLElement | null)?.focus();
   });
 </script>

--- a/src/components/docs/DocsSearch.astro
+++ b/src/components/docs/DocsSearch.astro
@@ -16,6 +16,8 @@ const strings = JSON.stringify({
   empty: t("docs.search.empty"),
   unavailable: t("docs.search.unavailable"),
   results: t("docs.search.results"),
+  countOne: t("docs.search.countOne"),
+  countMany: t("docs.search.countMany"),
 });
 ---
 
@@ -36,6 +38,10 @@ const strings = JSON.stringify({
   <div class="docs-search-panel">
     <div class="docs-search-inputrow">
       <Search class="w-4 h-4 shrink-0 text-on-surface-muted" />
+      {/* A combobox, not a bare input: the arrow keys move a highlight through
+          the listbox below while focus stays here, and only aria-activedescendant
+          tells a screen reader which hit is currently selected. Without it the
+          arrow-key navigation was completely silent. */}
       <input
         data-search-input
         type="search"
@@ -44,12 +50,19 @@ const strings = JSON.stringify({
         enterkeyhint="search"
         placeholder={t("docs.search.placeholder")}
         aria-label={t("docs.search.label")}
+        role="combobox"
+        aria-expanded="false"
         aria-controls="docs-search-results"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
       />
       <kbd class="docs-search-kbd">Esc</kbd>
     </div>
     <div id="docs-search-results" class="docs-search-results" data-search-results role="listbox" aria-label={t("docs.search.results")}></div>
     <p data-search-status class="docs-search-status" role="status" aria-live="polite"></p>
+    {/* Result counts go to their own off-screen region so the visible status
+        line stays reserved for the "no results" / "unavailable" messages. */}
+    <p data-search-count class="sr-only" role="status" aria-live="polite"></p>
   </div>
 </dialog>
 
@@ -76,6 +89,7 @@ const strings = JSON.stringify({
     input: HTMLInputElement,
     list: HTMLDivElement,
     status: HTMLParagraphElement,
+    count: HTMLParagraphElement,
   ) {
     const strings = JSON.parse(dialog.dataset.strings || "{}") as Record<string, string>;
 
@@ -122,6 +136,7 @@ const strings = JSON.stringify({
       const all = items();
       if (!all.length) {
         active = -1;
+        input.removeAttribute("aria-activedescendant");
         return;
       }
       // Wrap around in both directions.
@@ -130,12 +145,30 @@ const strings = JSON.stringify({
         const on = i === active;
         el.classList.toggle("is-active", on);
         el.setAttribute("aria-selected", String(on));
-        if (on) el.scrollIntoView({ block: "nearest" });
+        if (on) {
+          // Focus stays in the input, so this is the only thing that tells a
+          // screen reader which option the arrow keys just landed on.
+          input.setAttribute("aria-activedescendant", el.id);
+          el.scrollIntoView({ block: "nearest" });
+        }
       });
+    }
+
+    /** Keeps the combobox's popup state and the off-screen count in step. */
+    function setResultCount(n: number) {
+      input.setAttribute("aria-expanded", String(n > 0));
+      if (!n) {
+        count.textContent = "";
+        return;
+      }
+      count.textContent =
+        n === 1 ? strings.countOne : strings.countMany.replace("{n}", String(n));
     }
 
     function render(pages: ResultData[]) {
       list.innerHTML = "";
+      // Options need stable ids for aria-activedescendant to point at them.
+      let hitIndex = 0;
       for (const page of pages) {
         const group = document.createElement("div");
         group.className = "docs-search-group";
@@ -155,6 +188,7 @@ const strings = JSON.stringify({
           const hit = document.createElement("a");
           hit.className = "docs-search-hit";
           hit.href = cleanUrl(sub.url);
+          hit.id = `docs-search-hit-${hitIndex++}`;
           hit.setAttribute("role", "option");
           hit.setAttribute("aria-selected", "false");
 
@@ -178,13 +212,21 @@ const strings = JSON.stringify({
         list.appendChild(group);
       }
       setActive(0);
+      setResultCount(hitIndex);
+    }
+
+    /** Empty the listbox and reset every attribute that describes it. */
+    function clearResults() {
+      list.innerHTML = "";
+      active = -1;
+      input.removeAttribute("aria-activedescendant");
+      setResultCount(0);
     }
 
     async function run(query: string) {
       const token = ++seq;
       if (!query.trim()) {
-        list.innerHTML = "";
-        active = -1;
+        clearResults();
         setStatus("");
         return;
       }
@@ -192,7 +234,7 @@ const strings = JSON.stringify({
       const pf = await loadPagefind();
       if (token !== seq) return;
       if (!pf) {
-        list.innerHTML = "";
+        clearResults();
         setStatus(strings.unavailable);
         return;
       }
@@ -206,8 +248,7 @@ const strings = JSON.stringify({
       if (token !== seq) return;
 
       if (!pages.length) {
-        list.innerHTML = "";
-        active = -1;
+        clearResults();
         setStatus(strings.empty);
         return;
       }
@@ -219,8 +260,7 @@ const strings = JSON.stringify({
       if (dialog.open) return;
       dialog.showModal();
       input.value = "";
-      list.innerHTML = "";
-      active = -1;
+      clearResults();
       setStatus("");
       // Warm the bundle while the user is still typing their first character.
       void loadPagefind();
@@ -277,8 +317,9 @@ const strings = JSON.stringify({
   const input = dialog?.querySelector<HTMLInputElement>("[data-search-input]");
   const list = dialog?.querySelector<HTMLDivElement>("[data-search-results]");
   const status = dialog?.querySelector<HTMLParagraphElement>("[data-search-status]");
+  const count = dialog?.querySelector<HTMLParagraphElement>("[data-search-count]");
 
-  if (dialog && trigger && input && list && status) {
-    initSearch(dialog, trigger, input, list, status);
+  if (dialog && trigger && input && list && status && count) {
+    initSearch(dialog, trigger, input, list, status, count);
   }
 </script>

--- a/src/components/docs/DocsSearch.astro
+++ b/src/components/docs/DocsSearch.astro
@@ -42,9 +42,15 @@ const strings = JSON.stringify({
           the listbox below while focus stays here, and only aria-activedescendant
           tells a screen reader which hit is currently selected. Without it the
           arrow-key navigation was completely silent. */}
+      {/* type="text", not "search": ARIA in HTML allows no role but `searchbox`
+          on type=search, so role="combobox" would be a conformance error — and
+          the native type=search Escape behaviour swallowed the first Escape to
+          clear the field instead of closing the dialog, contradicting the
+          "Esc" chip beside it. inputmode keeps the search key on phones. */}
       <input
         data-search-input
-        type="search"
+        type="text"
+        inputmode="search"
         autocomplete="off"
         spellcheck="false"
         enterkeyhint="search"
@@ -167,16 +173,24 @@ const strings = JSON.stringify({
 
     function render(pages: ResultData[]) {
       list.innerHTML = "";
-      // Options need stable ids for aria-activedescendant to point at them.
+      // Options need stable ids for aria-activedescendant to point at them,
+      // and each group needs one for its own label.
       let hitIndex = 0;
+      let groupIndex = 0;
       for (const page of pages) {
         const group = document.createElement("div");
         group.className = "docs-search-group";
 
         const heading = document.createElement("div");
         heading.className = "docs-search-page";
+        heading.id = `docs-search-group-${groupIndex++}`;
         heading.textContent = page.meta?.title ?? page.url;
         group.appendChild(heading);
+        // Without this the page title is loose text inside the listbox and the
+        // options below it are unattributed; as a labelled group, a hit is
+        // announced along with the page it came from.
+        group.setAttribute("role", "group");
+        group.setAttribute("aria-labelledby", heading.id);
 
         // Prefer the per-section sub-results (they deep-link to the heading
         // anchor); fall back to the whole-page excerpt when there are none.

--- a/src/components/docs/PlatformSwitcher.tsx
+++ b/src/components/docs/PlatformSwitcher.tsx
@@ -51,6 +51,11 @@ export function PlatformSwitcher({ lang }: { lang: Lang }) {
             type="button"
             onClick={() => select(id)}
             aria-pressed={isActive}
+            // Below `sm` the inactive button's text label is display:none, which
+            // would leave a button whose only content is a decorative icon and
+            // therefore no accessible name. The label matches the visible text
+            // exactly, so it stays consistent once that text is shown again.
+            aria-label={t(labelKey)}
             className={`relative flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold [transition:color_280ms_cubic-bezier(0.16,1,0.3,1)] ${
               isActive ? "text-white" : "text-on-surface-muted hover:text-white"
             }`}
@@ -59,7 +64,7 @@ export function PlatformSwitcher({ lang }: { lang: Lang }) {
               <motion.span
                 layoutId="platform-toggle-indicator"
                 aria-hidden
-                className="absolute inset-0 bg-vibrant-red rounded-full"
+                className="absolute inset-0 bg-red-cta rounded-full"
                 transition={slideTransition}
               />
             )}

--- a/src/components/docs/TableOfContents.astro
+++ b/src/components/docs/TableOfContents.astro
@@ -15,9 +15,12 @@ const t = getT(lang);
 const entries = headings.filter((h) => h.depth === 2 || h.depth === 3);
 ---
 
+{/* The wrapper is a div, not an <aside>: the <nav> inside is the landmark, and
+    as an <aside> this element added a second, unnamed `complementary` landmark
+    around it — the same redundancy removed from the docs sidebar. */}
 {
   entries.length > 1 && (
-    <aside class="docs-toc-aside" data-pagefind-ignore>
+    <div class="docs-toc-aside" data-pagefind-ignore>
       <nav class="docs-toc" aria-labelledby="docs-toc-title">
         <div id="docs-toc-title" class="text-xs font-bold uppercase tracking-widest text-vibrant-orange mb-3">
           {t("docs.onThisPage")}
@@ -30,7 +33,7 @@ const entries = headings.filter((h) => h.depth === 2 || h.depth === 3);
           ))}
         </ul>
       </nav>
-    </aside>
+    </div>
   )
 }
 

--- a/src/components/landing/CtaSection.astro
+++ b/src/components/landing/CtaSection.astro
@@ -5,6 +5,7 @@ import Coffee from "@/src/components/icons/Coffee.astro";
 import DownloadMenu from "@/src/islands/DownloadMenu.tsx";
 import { getT, type Lang } from "@/src/i18n/t";
 import { localizePath } from "@/src/i18n/routing";
+import { resolveDownloads } from "@/src/lib/release";
 
 interface Props {
   lang: Lang;
@@ -12,6 +13,8 @@ interface Props {
 
 const { lang } = Astro.props;
 const t = getT(lang);
+
+const downloads = await resolveDownloads();
 
 const docsHref = localizePath("/docs", lang);
 ---
@@ -28,6 +31,7 @@ const docsHref = localizePath("/docs", lang);
     <div class="flex justify-center">
       <DownloadMenu
         lang={lang}
+        downloads={downloads}
         className="w-full sm:w-auto"
         triggerClassName="btn-press w-full sm:w-auto bg-red-cta hover:bg-red-cta-hover text-white font-bold text-lg px-8 lg:px-10 py-4 lg:py-5 rounded-2xl inline-flex items-center justify-center gap-3 transition-all hover:-translate-y-1 whitespace-nowrap"
         client:load

--- a/src/components/landing/CtaSection.astro
+++ b/src/components/landing/CtaSection.astro
@@ -49,7 +49,7 @@ const docsHref = localizePath("/docs", lang);
         {t("support.cta")}
       </a>
     </div>
-    <p class="mt-4 text-xs text-on-surface-muted/70">
+    <p class="mt-4 text-xs text-on-surface-muted/75">
       {t("support.note")}
     </p>
   </div>

--- a/src/components/landing/CtaSection.astro
+++ b/src/components/landing/CtaSection.astro
@@ -47,6 +47,7 @@ const docsHref = localizePath("/docs", lang);
       >
         <Coffee class="w-4 h-4" />
         {t("support.cta")}
+        <span class="sr-only"> ({t("a11y.newTab")})</span>
       </a>
     </div>
     <p class="mt-4 text-xs text-on-surface-muted/75">

--- a/src/components/landing/CtaSection.astro
+++ b/src/components/landing/CtaSection.astro
@@ -29,7 +29,7 @@ const docsHref = localizePath("/docs", lang);
       <DownloadMenu
         lang={lang}
         className="w-full sm:w-auto"
-        triggerClassName="btn-press w-full sm:w-auto bg-vibrant-red hover:bg-red-500 text-white font-bold text-lg px-8 lg:px-10 py-4 lg:py-5 rounded-2xl inline-flex items-center justify-center gap-3 transition-all hover:-translate-y-1 whitespace-nowrap"
+        triggerClassName="btn-press w-full sm:w-auto bg-red-cta hover:bg-red-cta-hover text-white font-bold text-lg px-8 lg:px-10 py-4 lg:py-5 rounded-2xl inline-flex items-center justify-center gap-3 transition-all hover:-translate-y-1 whitespace-nowrap"
         client:load
       />
     </div>

--- a/src/components/landing/Features.astro
+++ b/src/components/landing/Features.astro
@@ -24,10 +24,10 @@ const accentOrange = "--card-accent: rgba(251, 146, 60, 0.25)";
 const accentBlue = "--card-accent: rgba(56, 189, 248, 0.25)";
 const accentIndigo = "--card-accent: rgba(129, 140, 248, 0.25)";
 ---
-<section id="features" class="py-24 lg:py-32 px-6 lg:px-8 bg-surface border-y border-border scroll-mt-24">
+<section id="features" class="py-24 lg:py-32 px-6 lg:px-8 bg-surface border-y border-border scroll-mt-24" aria-labelledby="features-heading">
   <div class="max-w-7xl mx-auto">
     <div class="scroll-reveal mb-16 lg:mb-24 max-w-2xl">
-      <h2 class="text-4xl lg:text-6xl font-headline font-bold text-white mb-6 tracking-tight">{t("features.heading")}</h2>
+      <h2 id="features-heading" class="text-4xl lg:text-6xl font-headline font-bold text-white mb-6 tracking-tight">{t("features.heading")}</h2>
       <p class="text-on-surface-muted text-lg lg:text-xl leading-relaxed">{t("features.subheading")}</p>
     </div>
 

--- a/src/components/landing/UseCases.astro
+++ b/src/components/landing/UseCases.astro
@@ -17,10 +17,10 @@ const cases = [
   { Icon: LifeBuoy, title: t("useCases.case3.title"), description: t("useCases.case3.description") },
 ];
 ---
-<section class="py-20 lg:py-28 px-6 lg:px-8 bg-community-bg border-t border-border">
+<section class="py-20 lg:py-28 px-6 lg:px-8 bg-community-bg border-t border-border" aria-labelledby="usecases-heading">
   <div class="max-w-7xl mx-auto">
     <div class="scroll-reveal mb-14 lg:mb-20 max-w-2xl">
-      <h2 class="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t("useCases.heading")}</h2>
+      <h2 id="usecases-heading" class="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t("useCases.heading")}</h2>
       <p class="text-on-surface-muted text-lg leading-relaxed">{t("useCases.subheading")}</p>
     </div>
 

--- a/src/components/radios/RadiosBanner.astro
+++ b/src/components/radios/RadiosBanner.astro
@@ -71,6 +71,7 @@ const DONATE_RADIO_URL =
       >
         <Download class="w-4 h-4 transition-transform group-hover/cta:translate-y-0.5 motion-reduce:transform-none" />
         {t("radios.apk.cta")}
+        <span class="sr-only"> ({t("a11y.newTab")})</span>
       </a>
     </div>
 
@@ -95,6 +96,7 @@ const DONATE_RADIO_URL =
             >
               Ko-fi
               <ExternalLink class="w-3 h-3" />
+              <span class="sr-only"> ({t("a11y.newTab")})</span>
             </a>
             . {t("radios.donate.kofiUnit")}
           </p>

--- a/src/components/radios/RadiosBanner.astro
+++ b/src/components/radios/RadiosBanner.astro
@@ -100,7 +100,7 @@ const DONATE_RADIO_URL =
           </p>
         </div>
       </div>
-      <p class="flex items-start gap-1.5 text-xs text-on-surface-muted/70 leading-relaxed">
+      <p class="flex items-start gap-1.5 text-xs text-on-surface-muted/75 leading-relaxed">
         <AlertCircle class="w-3.5 h-3.5 mt-0.5 shrink-0" />
         <span>{t("radios.donate.disclaimer")}</span>
       </p>

--- a/src/components/radios/RadiosBanner.astro
+++ b/src/components/radios/RadiosBanner.astro
@@ -67,7 +67,7 @@ const DONATE_RADIO_URL =
         href="https://github.com/jcalado/voxdmr-site/releases"
         target="_blank"
         rel="noopener noreferrer"
-        class="btn-press group/cta mt-auto inline-flex items-center justify-center gap-2 bg-vibrant-red hover:bg-red-500 text-white px-6 py-3 rounded-2xl font-bold hover:scale-105 transition-all whitespace-nowrap shadow-lg shadow-vibrant-red/20"
+        class="btn-press group/cta mt-auto inline-flex items-center justify-center gap-2 bg-red-cta hover:bg-red-cta-hover text-white px-6 py-3 rounded-2xl font-bold hover:scale-105 transition-all whitespace-nowrap shadow-lg shadow-vibrant-red/20"
       >
         <Download class="w-4 h-4 transition-transform group-hover/cta:translate-y-0.5 motion-reduce:transform-none" />
         {t("radios.apk.cta")}

--- a/src/components/radios/RadiosContribute.astro
+++ b/src/components/radios/RadiosContribute.astro
@@ -41,5 +41,6 @@ const SUBMIT_RADIO_URL =
   >
     <Plus class="w-4 h-4" />
     {t("radios.contribute.cta")}
+    <span class="sr-only"> ({t("a11y.newTab")})</span>
   </a>
 </div>

--- a/src/docs/docs.css
+++ b/src/docs/docs.css
@@ -48,8 +48,12 @@
 .prose h2 { color: white; font-size: 1.35rem; font-weight: 700; margin: 3.5rem 0 0.75rem 0; }
 .prose h3 { color: white; font-size: 1.1rem; font-weight: 600; margin: 2rem 0 0.5rem 0; }
 .prose p { margin: 0 0 1rem 0; }
-.prose a { color: #EF4444; text-decoration: none; }
-.prose a:hover { text-decoration: underline; }
+/* Underlined, not colour-only. Red on the body text around it is 1.97:1 —
+   well under the 3:1 that WCAG 1.4.1 requires before colour alone may carry
+   the "this is a link" meaning. The underline is what makes them findable for
+   anyone who cannot separate the two hues. */
+.prose a { color: #EF4444; text-decoration: underline; text-underline-offset: 0.2em; text-decoration-thickness: 1px; }
+.prose a:hover { text-decoration-thickness: 2px; }
 .prose ul, .prose ol { margin: 0 0 1rem 0; padding-left: 1.5rem; }
 .prose ol { list-style-type: decimal; }
 .prose ul { list-style-type: disc; }
@@ -188,7 +192,8 @@
   line-height: 1;
   padding: 0.25rem 0.35rem;
   border-radius: 0.3rem;
-  color: #64748B;
+  /* #64748B read at 2.91:1 on this chip — under AA for 10px text. */
+  color: #94A3B8;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }

--- a/src/docs/docs.css
+++ b/src/docs/docs.css
@@ -106,6 +106,11 @@
 .prose hr { border: none; border-top: 1px solid rgba(255, 255, 255, 0.07); margin: 2rem 0; }
 .prose img { max-width: 260px; border-radius: 0.75rem; border: 1px solid rgba(255, 255, 255, 0.07); cursor: zoom-in; transition: opacity 0.15s; }
 .prose img:hover { opacity: 0.85; }
+
+/* Every content image is wrapped in a real <button> at runtime (DocsLayout.astro)
+   so the lightbox can be opened from the keyboard — a bare <img> with a click
+   handler is mouse-only. The button is a bare box; the image keeps its own look. */
+.prose .doc-zoom-btn { display: block; width: fit-content; padding: 0; border: 0; background: none; cursor: zoom-in; }
 .prose strong { color: white; font-weight: 600; }
 
 /* Embedded video (::youtube directive) */
@@ -113,8 +118,14 @@
 .prose .video-embed iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
 
 /* Image modal */
-.doc-modal-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: rgba(0, 0, 0, 0.85); backdrop-filter: blur(4px); cursor: zoom-out; }
-.doc-modal-img { max-height: 90vh; max-width: 90vw; border-radius: 0.75rem; object-fit: contain; view-transition-name: doc-image; }
+/* A native <dialog>, so the focus trap, Esc-to-close and focus restore on close
+   all come from the platform rather than hand-rolled listeners. */
+.doc-modal { padding: 0; border: 0; background: transparent; width: 100vw; height: 100vh; max-width: 100vw; max-height: 100vh; cursor: zoom-out; }
+.doc-modal[open] { display: flex; align-items: center; justify-content: center; }
+.doc-modal::backdrop { background: rgba(0, 0, 0, 0.85); backdrop-filter: blur(4px); }
+.doc-modal-img { max-height: 90vh; max-width: 90vw; border-radius: 0.75rem; object-fit: contain; view-transition-name: doc-image; cursor: default; }
+.doc-modal-close { position: fixed; top: 1rem; right: 1rem; display: inline-flex; align-items: center; justify-content: center; width: 2.5rem; height: 2.5rem; border-radius: 9999px; border: 1px solid rgba(255, 255, 255, 0.07); background: #1E293B; color: #fff; cursor: pointer; }
+.doc-modal-close:hover { background: #DC2626; border-color: #DC2626; }
 
 /* View Transition animation */
 ::view-transition-old(doc-image),
@@ -141,12 +152,18 @@
 }
 
 @media (max-width: 1023px) {
+  /* `visibility: hidden` is what keeps the closed drawer out of the tab order
+     and the accessibility tree — translating it off-screen alone leaves every
+     sidebar link focusable. Transitioning visibility alongside the transform
+     defers the flip to the end of the slide, so the animation still plays out
+     (same trick as `.site-mobile-menu` in index.css). */
   .docs-sidebar-aside {
     position: fixed; top: 3.5rem; left: 0; bottom: 0; z-index: 40;
     transform: translateX(-100%);
-    transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    visibility: hidden;
+    transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), visibility 0.25s;
   }
-  .docs-sidebar-open .docs-sidebar-aside { transform: translateX(0); }
+  .docs-sidebar-open .docs-sidebar-aside { transform: translateX(0); visibility: visible; }
   .docs-sidebar-backdrop {
     display: block; position: fixed; inset: 3.5rem 0 0 0; z-index: 30;
     background: rgba(0, 0, 0, 0.6); opacity: 0; pointer-events: none;

--- a/src/docs/docs.css
+++ b/src/docs/docs.css
@@ -54,6 +54,10 @@
    anyone who cannot separate the two hues. */
 .prose a { color: #EF4444; text-decoration: underline; text-underline-offset: 0.2em; text-decoration-thickness: 1px; }
 .prose a:hover { text-decoration-thickness: 2px; }
+/* Blockquotes and callouts sit on a lighter ground, where #EF4444 drops to
+   3.89:1 and 3.6:1. A step lighter clears AA on both without changing the
+   colour's character. */
+.prose blockquote a, .prose .callout a { color: #F87171; }
 .prose ul, .prose ol { margin: 0 0 1rem 0; padding-left: 1.5rem; }
 .prose ol { list-style-type: decimal; }
 .prose ul { list-style-type: disc; }
@@ -256,9 +260,7 @@
   font-size: 0.95rem;
   font-family: inherit;
 }
-.docs-search-inputrow input::placeholder { color: #64748B; }
-/* The type=search clear affordance duplicates Esc and breaks the row rhythm. */
-.docs-search-inputrow input::-webkit-search-cancel-button { display: none; }
+.docs-search-inputrow input::placeholder { color: #94A3B8; }
 
 .docs-search-results {
   max-height: min(60vh, 26rem);
@@ -305,13 +307,15 @@
 }
 .docs-search-hit mark {
   background: none;
-  color: #EF4444;
+  /* 4.28:1 against the highlighted row; a step lighter clears AA. */
+  color: #F87171;
   font-weight: 600;
 }
 
 .docs-search-status {
   padding: 1.1rem 1.25rem;
-  color: #64748B;
+  /* 3.75:1 before — this is the "no results" / "unavailable" copy. */
+  color: #94A3B8;
   font-size: 0.8125rem;
 }
 .docs-search-status[hidden] { display: none; }
@@ -346,14 +350,17 @@
   .docs-toc-aside { width: 15rem; padding-right: 1.5rem; }
 }
 
-.docs-toc ul { list-style: none; margin: 0; padding: 0; }
+/* Room for the focus ring's left edge: the links sit flush against the rail's
+   left edge, and the scroll container clipped the outline there. */
+.docs-toc ul { list-style: none; margin: 0; padding: 0 0 0 3px; }
 .docs-toc li[hidden] { display: none; }
 .docs-toc li[data-toc-depth="3"] { padding-left: 0.85rem; }
 .docs-toc a {
   display: block;
   padding: 0.3rem 0 0.3rem 0.75rem;
   border-left: 2px solid rgba(255, 255, 255, 0.09);
-  color: #64748B;
+  /* #64748B read at 4.24:1 on the page ground — just under AA at 13px. */
+  color: #94A3B8;
   font-size: 0.8125rem;
   line-height: 1.45;
   text-decoration: none;

--- a/src/downloads.ts
+++ b/src/downloads.ts
@@ -1,11 +1,17 @@
 /**
- * The download targets, shared by the `DownloadMenu` island and the mobile nav
- * so the two can't drift apart.
+ * The download targets, shared by the `DownloadMenu` island, the mobile nav and
+ * the footer so they can't drift apart.
  *
- * The desktop assets resolve through GitHub's `/releases/latest/download/<asset>`
- * redirect, so these URLs never need a version bump. The APKs have
- * version-stamped filenames, so the 32-bit build links to the releases page
- * rather than a direct asset.
+ * These are the **fallback** URLs. `src/lib/release.ts` resolves them against
+ * the real assets of the latest GitHub release at build time and is what the
+ * pages actually render; this list is what ships if the API is unreachable.
+ * Keep it working on its own: the desktop entries go through GitHub's
+ * `/releases/latest/download/<asset>` redirect so they survive a version bump,
+ * and the APK — whose filename is version-stamped and so cannot be guessed —
+ * points at the releases page.
+ *
+ * Everything here is serialized into the DownloadMenu island's props, so it
+ * must stay JSON-safe (the asset-matching patterns live in release.ts).
  */
 const RELEASES = "https://github.com/jcalado/voxdmr-site/releases";
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -166,6 +166,8 @@
   "docs.goToInstallation": "Go to Installation →",
   "docs.backToSite": "← Back to site",
   "docs.slash": "/ Docs",
+  "docs.image.zoom": "Zoom in on",
+  "docs.image.close": "Close image",
   "docs.platform.label": "Show instructions for",
   "docs.platform.desktop": "Desktop",
   "docs.platform.mobile": "Mobile",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,11 @@
 {
+  "a11y.skipToContent": "Skip to content",
+  "a11y.primaryNav": "Main",
+  "a11y.footerNav": "Footer",
+  "a11y.toggleMenu": "Menu",
+  "a11y.toggleSidebar": "Documentation sections",
+  "a11y.newTab": "opens in a new tab",
+
   "nav.screenshots": "Screenshots",
   "nav.features": "Features",
   "nav.docs": "Docs",
@@ -158,6 +165,8 @@
   "docs.search.placeholder": "Search the docs…",
   "docs.search.results": "Search results",
   "docs.search.empty": "No results. Try a different word.",
+  "docs.search.countOne": "1 result",
+  "docs.search.countMany": "{n} results",
   "docs.search.unavailable": "Search is only available in the built site — run `npm run build`.",
   "docs.previous": "Previous",
   "docs.next": "Next",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,7 @@
   "a11y.primaryNav": "Main",
   "a11y.footerNav": "Footer",
   "a11y.toggleMenu": "Menu",
-  "a11y.toggleSidebar": "Documentation sections",
+  "a11y.docsSections": "Documentation sections",
   "a11y.newTab": "opens in a new tab",
 
   "nav.screenshots": "Screenshots",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -3,7 +3,7 @@
   "a11y.primaryNav": "Principal",
   "a11y.footerNav": "Rodapé",
   "a11y.toggleMenu": "Menu",
-  "a11y.toggleSidebar": "Secções da documentação",
+  "a11y.docsSections": "Secções da documentação",
   "a11y.newTab": "abre num novo separador",
 
   "nav.screenshots": "Capturas",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -166,6 +166,8 @@
   "docs.goToInstallation": "Ir para Instalação →",
   "docs.backToSite": "← Voltar ao site",
   "docs.slash": "/ Documentação",
+  "docs.image.zoom": "Ampliar",
+  "docs.image.close": "Fechar imagem",
   "docs.platform.label": "Mostrar instruções para",
   "docs.platform.desktop": "Desktop",
   "docs.platform.mobile": "Telemóvel",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -1,4 +1,11 @@
 {
+  "a11y.skipToContent": "Saltar para o conteúdo",
+  "a11y.primaryNav": "Principal",
+  "a11y.footerNav": "Rodapé",
+  "a11y.toggleMenu": "Menu",
+  "a11y.toggleSidebar": "Secções da documentação",
+  "a11y.newTab": "abre num novo separador",
+
   "nav.screenshots": "Capturas",
   "nav.features": "Funcionalidades",
   "nav.docs": "Documentação",
@@ -158,6 +165,8 @@
   "docs.search.placeholder": "Pesquisar na documentação…",
   "docs.search.results": "Resultados da pesquisa",
   "docs.search.empty": "Sem resultados. Tente outra palavra.",
+  "docs.search.countOne": "1 resultado",
+  "docs.search.countMany": "{n} resultados",
   "docs.search.unavailable": "A pesquisa só está disponível no site compilado — execute `npm run build`.",
   "docs.previous": "Anterior",
   "docs.next": "Seguinte",

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,41 @@ html {
   }
 }
 
+/* Site-wide focus indicator. Most interactive elements had none of their own
+   and fell back to the UA outline, which is close to invisible on these
+   near-black backgrounds in Firefox. Blue rather than the red accent so the
+   ring never reads as a hover state on the red CTAs.
+
+   Components that define their own `focus-visible:ring-*` also carry
+   `focus:outline-none`, whose higher specificity suppresses this outline —
+   so they keep their ring and nothing doubles up. */
+:focus-visible {
+  outline: 2px solid var(--color-vibrant-blue);
+  outline-offset: 2px;
+}
+
+/* Skip link (rendered in Layout.astro). Off-screen until it takes focus. */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: 0;
+  z-index: 100;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0 0 1rem 1rem;
+  background: var(--color-surface-raised);
+  color: var(--color-on-surface);
+  font-weight: 700;
+  /* transform rather than `top` so revealing it doesn't trigger layout. */
+  transform: translateY(-150%);
+  transition: transform 0.15s ease;
+}
+/* `:focus`, not `:focus-visible` — a skip link is only ever reached by
+   keyboard, and this keeps it working in engines that scope focus-visible
+   more tightly. */
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 /* Mobile nav dropdown (SiteNav). Pure CSS; a tiny script flips data-open. */
 .site-mobile-menu {
   opacity: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -179,6 +179,10 @@ html {
   opacity: 1;
   transform: translateY(0);
 }
+/* Note: without JS the IntersectionObserver never runs and `.revealed` is
+   never added, which would leave most of the page at opacity 0 — a blank site
+   rather than a site without animation. The <noscript> block in
+   Layout.astro's <head> neutralises this rule in that case. */
 
 /* Decorative animations migrated out of Framer Motion (hero blobs, hero glow,
    CTA logo pulse). Values match the original motion props 1:1. */

--- a/src/index.css
+++ b/src/index.css
@@ -68,6 +68,23 @@ html {
   outline-offset: 2px;
 }
 
+/* The skip link's target. Two things need handling:
+   - The docs <main> is a scroll container, which makes it programmatically
+     focusable, so following the skip link drew the focus ring around the
+     entire content column. Suppress it there — the ring is meant for
+     controls, and the jump is already obvious from the scroll.
+   - Landing on the target puts its top edge exactly under the sticky nav,
+     hiding the first line of the heading. scroll-margin-top clears it. */
+#main-content {
+  scroll-margin-top: 7rem; /* clears the 6rem site nav */
+}
+#main-content:focus {
+  outline: none;
+}
+[data-docs-root] #main-content {
+  scroll-margin-top: 4.5rem; /* the docs nav is 3.5rem */
+}
+
 /* Skip link (rendered in Layout.astro). Off-screen until it takes focus. */
 .skip-link {
   position: absolute;

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,12 @@ html {
   --color-vibrant-blue: #38BDF8;
   --color-vibrant-orange: #FB923C;
   --color-vibrant-red: #EF4444;
+  /* Filled-button red. White on --color-vibrant-red is only 3.76:1, under the
+     4.5:1 WCAG AA floor, so every red fill that carries white text uses these
+     two darker steps instead (4.83:1 and 6.47:1). --color-vibrant-red stays the
+     accent for red *text* on a dark ground, where it reads at 5.36:1. */
+  --color-red-cta: #DC2626;
+  --color-red-cta-hover: #B91C1C;
   --color-accent-tertiary: #818CF8;
   --color-status-online: #22C55E;
   --color-community-bg: #020617;

--- a/src/islands/DownloadMenu.tsx
+++ b/src/islands/DownloadMenu.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import type { LucideIcon } from "lucide-react";
 import { ChevronDown, Cpu, Download, Monitor, Smartphone, Terminal } from "lucide-react";
 import { getT, type Lang } from "@/src/i18n/t";
-import { downloads, type Download as DownloadTarget } from "@/src/downloads";
+import { type Download as DownloadTarget } from "@/src/downloads";
 
 const ICONS: Record<DownloadTarget["key"], LucideIcon> = {
   playStore: Smartphone,
@@ -14,6 +14,8 @@ const ICONS: Record<DownloadTarget["key"], LucideIcon> = {
 
 type DownloadMenuProps = {
   lang: Lang;
+  /** Resolved at build time against the latest release (see lib/release.ts). */
+  downloads: DownloadTarget[];
   /** Classes for the trigger button so it can match each call site's CTA style. */
   triggerClassName: string;
   /** Wrapper classes — used to inherit sizing (e.g. `w-full sm:w-auto`). */
@@ -24,6 +26,7 @@ type DownloadMenuProps = {
 
 export default function DownloadMenu({
   lang,
+  downloads,
   triggerClassName,
   className,
   align = "left",

--- a/src/islands/DownloadMenu.tsx
+++ b/src/islands/DownloadMenu.tsx
@@ -34,8 +34,8 @@ export default function DownloadMenu({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
-  /** Set when the menu was opened from the keyboard, so focus moves into it. */
-  const focusOnOpen = useRef(false);
+  /** Which item to focus once the menu mounts, or null for a mouse open. */
+  const focusOnOpen = useRef<"first" | "last" | null>(null);
 
   const MENU_WIDTH = 256; // matches w-64
 
@@ -48,8 +48,8 @@ export default function DownloadMenu({
     triggerRef.current?.focus();
   }
 
-  function openWithFocus(fromKeyboard: boolean) {
-    focusOnOpen.current = fromKeyboard;
+  function openWithFocus(focus: "first" | "last" | null) {
+    focusOnOpen.current = focus;
     setOpen(true);
   }
 
@@ -102,9 +102,22 @@ export default function DownloadMenu({
   // reachable at all; Tab out then closes it and resumes from the trigger.
   useEffect(() => {
     if (!open || !focusOnOpen.current) return;
-    focusOnOpen.current = false;
-    menuItems()[0]?.focus();
+    const items = menuItems();
+    const target = focusOnOpen.current === "last" ? items[items.length - 1] : items[0];
+    focusOnOpen.current = null;
+    target?.focus();
   }, [open]);
+
+  // A menu left open behind the user is worse than one that closes: its
+  // document-level Escape handler would otherwise yank focus back to the
+  // trigger from wherever they had tabbed on to.
+  function onFocusOut(e: React.FocusEvent<HTMLDivElement>) {
+    const next = e.relatedTarget as Node | null;
+    if (!next) return; // Focus left the window entirely; leave the menu alone.
+    if (!triggerRef.current?.contains(next) && !menuRef.current?.contains(next)) {
+      setOpen(false);
+    }
+  }
 
   /** Roving arrow-key movement between menu items, per the ARIA menu pattern. */
   function onMenuKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
@@ -124,6 +137,11 @@ export default function DownloadMenu({
     } else if (e.key === "End") {
       e.preventDefault();
       items[items.length - 1].focus();
+    } else if (e.key === " ") {
+      // Native anchors ignore Space; the ARIA menu pattern expects it to
+      // activate the item just like Enter does.
+      e.preventDefault();
+      (document.activeElement as HTMLAnchorElement | null)?.click();
     } else if (e.key === "Tab") {
       // Let Tab do its normal thing, but from the trigger — otherwise focus
       // would land wherever the portal sits at the end of <body>.
@@ -132,20 +150,31 @@ export default function DownloadMenu({
   }
 
   function onTriggerKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
-    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-      e.preventDefault();
-      if (open) menuItems()[e.key === "ArrowDown" ? 0 : menuItems().length - 1]?.focus();
-      else openWithFocus(true);
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    e.preventDefault();
+    const edge = e.key === "ArrowDown" ? "first" : "last";
+    if (!open) {
+      openWithFocus(edge);
+      return;
     }
+    const items = menuItems();
+    (edge === "first" ? items[0] : items[items.length - 1])?.focus();
   }
 
   return (
-    <div className={className}>
+    <div className={className} onBlur={onFocusOut}>
       <button
         ref={triggerRef}
         id={`${menuId}-trigger`}
         type="button"
-        onClick={() => (open ? setOpen(false) : openWithFocus(false))}
+        // Enter and Space on a button arrive as a click, not a keydown, so this
+        // — not onKeyDown — is the path most keyboard users take. `detail === 0`
+        // marks a click the browser synthesised from a key press, which is what
+        // distinguishes it from a real pointer click.
+        onClick={(e) => {
+          if (open) setOpen(false);
+          else openWithFocus(e.detail === 0 ? "first" : null);
+        }}
         onKeyDown={onTriggerKeyDown}
         aria-haspopup="menu"
         aria-expanded={open}

--- a/src/islands/DownloadMenu.tsx
+++ b/src/islands/DownloadMenu.tsx
@@ -210,6 +210,7 @@ export default function DownloadMenu({
                 >
                   <Icon className="w-4 h-4 shrink-0 text-vibrant-blue" />
                   {t(labelKey)}
+                  {external && <span className="sr-only"> ({t("a11y.newTab")})</span>}
                 </a>
               );
             })}

--- a/src/islands/DownloadMenu.tsx
+++ b/src/islands/DownloadMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { LucideIcon } from "lucide-react";
 import { ChevronDown, Cpu, Download, Monitor, Smartphone, Terminal } from "lucide-react";
@@ -33,8 +33,25 @@ export default function DownloadMenu({
   const [coords, setCoords] = useState({ top: 0, left: 0 });
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  /** Set when the menu was opened from the keyboard, so focus moves into it. */
+  const focusOnOpen = useRef(false);
 
   const MENU_WIDTH = 256; // matches w-64
+
+  const menuItems = () =>
+    Array.from(menuRef.current?.querySelectorAll<HTMLAnchorElement>("[role='menuitem']") ?? []);
+
+  /** Close and hand focus back to the trigger — the expected exit for Escape. */
+  function closeAndRestore() {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function openWithFocus(fromKeyboard: boolean) {
+    focusOnOpen.current = fromKeyboard;
+    setOpen(true);
+  }
 
   // The menu is portaled to <body> so no `overflow-hidden` ancestor (e.g. the
   // hero header) can clip it. Position it as a fixed box anchored to the
@@ -67,7 +84,10 @@ export default function DownloadMenu({
       }
     };
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeAndRestore();
+      }
     };
     document.addEventListener("mousedown", onPointerDown);
     document.addEventListener("keydown", onKeyDown);
@@ -77,14 +97,59 @@ export default function DownloadMenu({
     };
   }, [open]);
 
+  // The menu is portaled to <body>, so it is nowhere near the trigger in the
+  // tab order. Moving focus into it on a keyboard open is what makes it
+  // reachable at all; Tab out then closes it and resumes from the trigger.
+  useEffect(() => {
+    if (!open || !focusOnOpen.current) return;
+    focusOnOpen.current = false;
+    menuItems()[0]?.focus();
+  }, [open]);
+
+  /** Roving arrow-key movement between menu items, per the ARIA menu pattern. */
+  function onMenuKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const items = menuItems();
+    if (!items.length) return;
+    const i = items.indexOf(document.activeElement as HTMLAnchorElement);
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      items[(i + 1) % items.length].focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      items[(i - 1 + items.length) % items.length].focus();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      items[0].focus();
+    } else if (e.key === "End") {
+      e.preventDefault();
+      items[items.length - 1].focus();
+    } else if (e.key === "Tab") {
+      // Let Tab do its normal thing, but from the trigger — otherwise focus
+      // would land wherever the portal sits at the end of <body>.
+      closeAndRestore();
+    }
+  }
+
+  function onTriggerKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (open) menuItems()[e.key === "ArrowDown" ? 0 : menuItems().length - 1]?.focus();
+      else openWithFocus(true);
+    }
+  }
+
   return (
     <div className={className}>
       <button
         ref={triggerRef}
+        id={`${menuId}-trigger`}
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => (open ? setOpen(false) : openWithFocus(false))}
+        onKeyDown={onTriggerKeyDown}
         aria-haspopup="menu"
         aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
         className={triggerClassName}
       >
         <Download className="w-5 h-5" />
@@ -96,7 +161,10 @@ export default function DownloadMenu({
         createPortal(
           <div
             ref={menuRef}
+            id={menuId}
             role="menu"
+            aria-labelledby={`${menuId}-trigger`}
+            onKeyDown={onMenuKeyDown}
             style={{ top: coords.top, left: coords.left, width: MENU_WIDTH }}
             className="fixed z-[60] origin-top rounded-2xl border border-border bg-slate-900/95 p-2 shadow-2xl shadow-black/50 backdrop-blur-xl"
           >

--- a/src/islands/RadiosGrid.tsx
+++ b/src/islands/RadiosGrid.tsx
@@ -230,7 +230,7 @@ function RadioCard({
               >
                 {radio.maker}
                 <ExternalLink className="w-3 h-3" aria-hidden="true" />
-                <span className="sr-only">{t("radios.makerAria")}</span>
+                <span className="sr-only">{t("radios.makerAria")} ({t("a11y.newTab")})</span>
               </a>
             ) : (
               <p className="mt-1 text-xs text-on-surface-muted">{radio.maker}</p>
@@ -309,6 +309,7 @@ function RadioCard({
                     <ExternalLink className="w-3.5 h-3.5 shrink-0 text-vibrant-blue" aria-hidden="true" />
                   )}
                   {t(link.labelKey)}
+                  <span className="sr-only"> ({t("a11y.newTab")})</span>
                 </a>
               ))}
             </div>

--- a/src/islands/RadiosGrid.tsx
+++ b/src/islands/RadiosGrid.tsx
@@ -444,7 +444,11 @@ export default function RadiosGrid({ lang }: RadiosGridProps) {
                 )}
                 <span className="relative inline-flex items-center gap-1.5">
                   {s === "all" ? t("radios.filter.all") : t(`radios.status.${s}`)}
-                  <span className={`tabular-nums text-xs ${active ? "text-white/70" : "text-on-surface-muted/60"}`}>
+                  {/* The counts were dimmed to /70 and /60, which land at 2.99:1
+                      and 3.39:1 — under AA for this 12px text. The smaller size
+                      already de-emphasises them, so the opacity that was doing
+                      the same job is dialled back to where both pass. */}
+                  <span className={`tabular-nums text-xs ${active ? "text-white" : "text-on-surface-muted/75"}`}>
                     {statusCount(s)}
                   </span>
                 </span>

--- a/src/islands/RadiosGrid.tsx
+++ b/src/islands/RadiosGrid.tsx
@@ -439,7 +439,7 @@ export default function RadiosGrid({ lang }: RadiosGridProps) {
                         ? { duration: 0 }
                         : { type: "tween", duration: 0.28, ease: [0.22, 1, 0.36, 1] }
                     }
-                    className="absolute inset-0 rounded-full bg-vibrant-red"
+                    className="absolute inset-0 rounded-full bg-red-cta"
                   />
                 )}
                 <span className="relative inline-flex items-center gap-1.5">

--- a/src/islands/RadiosGrid.tsx
+++ b/src/islands/RadiosGrid.tsx
@@ -111,7 +111,7 @@ function BoolCell({ value, t }: { value: Support; t: TFn }) {
     );
   if (value === "na")
     return (
-      <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-muted/75">
+      <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-muted">
         {t("radios.na")}
       </span>
     );
@@ -157,11 +157,11 @@ function ScoreMeter({ radio, score, t }: { radio: Radio; score: number; t: TFn }
               <span key={p.key} className="flex items-center justify-between gap-6">
                 <span className="text-on-surface-muted">{t(`radios.col.${p.key}`)}</span>
                 {p.counted ? (
-                  <span className={`tabular-nums font-semibold ${p.earned > 0 ? "text-emerald-300" : "text-on-surface-muted/60"}`}>
+                  <span className={`tabular-nums font-semibold ${p.earned > 0 ? "text-emerald-300" : "text-on-surface-muted"}`}>
                     {p.earned}/{p.weight}
                   </span>
                 ) : (
-                  <span className="tabular-nums font-semibold text-on-surface-muted/60">{t("radios.na")}</span>
+                  <span className="tabular-nums font-semibold text-on-surface-muted">{t("radios.na")}</span>
                 )}
               </span>
             ))}

--- a/src/islands/RadiosGrid.tsx
+++ b/src/islands/RadiosGrid.tsx
@@ -142,7 +142,9 @@ function ScoreMeter({ radio, score, t }: { radio: Radio; score: number; t: TFn }
           <button
             type="button"
             aria-label={t("radios.scoreHelp")}
-            className="text-on-surface-muted/70 hover:text-on-surface focus:outline-none focus-visible:text-on-surface cursor-help"
+            // No focus:outline-none here: a colour shift was this button's only
+            // focus cue, so it needs the site-wide focus ring.
+            className="text-on-surface-muted/75 hover:text-on-surface focus-visible:text-on-surface cursor-help"
           >
             <Info className="w-3.5 h-3.5" aria-hidden="true" />
           </button>

--- a/src/islands/RadiosGrid.tsx
+++ b/src/islands/RadiosGrid.tsx
@@ -111,7 +111,7 @@ function BoolCell({ value, t }: { value: Support; t: TFn }) {
     );
   if (value === "na")
     return (
-      <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-muted/70">
+      <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-muted/75">
         {t("radios.na")}
       </span>
     );
@@ -458,8 +458,15 @@ export default function RadiosGrid({ lang }: RadiosGridProps) {
         </div>
       </div>
 
-      {/* Result count */}
-      <p className="text-sm text-on-surface-muted mb-5 tabular-nums">
+      {/* Result count. A live region so typing in the search box or flipping a
+          filter announces how many radios are left — the change was previously
+          silent, visible only in this line. */}
+      <p
+        className="text-sm text-on-surface-muted mb-5 tabular-nums"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         {filtersActive
           ? `${visible.length} ${t("radios.countOf")} ${radios.length} ${t("radios.unit")}`
           : `${radios.length} ${t("radios.unit")}`}

--- a/src/islands/ScreenshotGallery.tsx
+++ b/src/islands/ScreenshotGallery.tsx
@@ -104,7 +104,7 @@ export default function ScreenshotGallery({ lang }: ScreenshotGalleryProps) {
                   <motion.span
                     layoutId="platform-toggle-indicator"
                     aria-hidden
-                    className="absolute inset-0 bg-vibrant-red rounded-full"
+                    className="absolute inset-0 bg-red-cta rounded-full"
                     transition={slideTransition}
                   />
                 )}
@@ -192,7 +192,7 @@ export default function ScreenshotGallery({ lang }: ScreenshotGalleryProps) {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: prefersReducedMotion ? 0 : 0.22, delay: prefersReducedMotion ? 0 : 0.15 }}
-              className="absolute top-4 right-4 lg:top-6 lg:right-6 inline-flex items-center justify-center w-10 h-10 rounded-full bg-surface-raised border border-border text-white hover:bg-vibrant-red hover:border-vibrant-red transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-vibrant-red focus-visible:ring-offset-2 focus-visible:ring-offset-community-bg"
+              className="absolute top-4 right-4 lg:top-6 lg:right-6 inline-flex items-center justify-center w-10 h-10 rounded-full bg-surface-raised border border-border text-white hover:bg-red-cta hover:border-red-cta transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-vibrant-red focus-visible:ring-offset-2 focus-visible:ring-offset-community-bg"
             >
               <X className="w-5 h-5" />
             </motion.button>

--- a/src/islands/ScreenshotGallery.tsx
+++ b/src/islands/ScreenshotGallery.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { Monitor, Smartphone, X } from "lucide-react";
 import { getT, type Lang } from "@/src/i18n/t";
@@ -48,16 +48,45 @@ export default function ScreenshotGallery({ lang }: ScreenshotGalleryProps) {
       : "columns-1 lg:columns-2";
 
   const [zoomed, setZoomed] = useState<{ src: string; alt: string; label: string } | null>(null);
+  /** The thumbnail that opened the lightbox, so focus can go back to it. */
+  const openerRef = useRef<HTMLElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!zoomed) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setZoomed(null); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setZoomed(null);
+        return;
+      }
+      // The overlay is modal, so Tab must not walk out into the page behind
+      // it. The close button is its only focusable element, which makes the
+      // trap a single stop rather than a cycle.
+      if (e.key === "Tab") {
+        e.preventDefault();
+        closeButtonRef.current?.focus();
+      }
+    };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
+    };
+  }, [zoomed]);
+
+  // Move focus into the dialog on open and return it to the thumbnail on
+  // close. Without this the overlay claimed aria-modal while a screen reader's
+  // focus stayed on the page underneath it.
+  useEffect(() => {
+    if (!zoomed) return;
+    closeButtonRef.current?.focus();
+    return () => {
+      const opener = openerRef.current;
+      // The thumbnail is gone if the platform toggle swapped the gallery out.
+      if (opener && document.contains(opener)) opener.focus();
+      openerRef.current = null;
     };
   }, [zoomed]);
 
@@ -80,7 +109,9 @@ export default function ScreenshotGallery({ lang }: ScreenshotGalleryProps) {
     <>
       <div className="mb-12 lg:mb-16 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
         <div className="max-w-2xl">
-          <h2 className="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t("screenshots.heading")}</h2>
+          {/* Named so the wrapping <section> in LandingBody can point its
+              aria-labelledby here. */}
+          <h2 id="screenshots-heading" className="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t("screenshots.heading")}</h2>
           <p className="text-on-surface-muted text-lg leading-relaxed">{t("screenshots.subheading")}</p>
         </div>
         <div
@@ -133,7 +164,10 @@ export default function ScreenshotGallery({ lang }: ScreenshotGalleryProps) {
               <motion.button
                 type="button"
                 layoutId={`zoom-${item.src}`}
-                onClick={() => setZoomed(item)}
+                onClick={(e) => {
+                  openerRef.current = e.currentTarget as HTMLElement;
+                  setZoomed(item);
+                }}
                 animate={{ opacity: isZoomed ? 0 : 1 }}
                 transition={zoomLayoutTransition}
                 aria-label={`${t("screenshots.zoomOpen")} ${item.label}`}
@@ -185,6 +219,7 @@ export default function ScreenshotGallery({ lang }: ScreenshotGalleryProps) {
               </picture>
             </motion.div>
             <motion.button
+              ref={closeButtonRef}
               type="button"
               onClick={() => setZoomed(null)}
               aria-label={t("screenshots.zoomClose")}

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -180,8 +180,11 @@ const home = localizePath("/", lang);
   );
   backdrop?.addEventListener("click", () => setSidebar(false));
   // Escape closes the drawer and hands focus back to the button that opened it.
+  // A modal <dialog> (the search panel) sits above the drawer and handles its
+  // own Escape, so defer to it rather than closing both and fighting over focus.
   document.addEventListener("keydown", (e) => {
     if (e.key !== "Escape" || !root?.classList.contains("docs-sidebar-open")) return;
+    if (document.querySelector("dialog[open]")) return;
     setSidebar(false);
     (toggle as HTMLElement | null)?.focus();
   });
@@ -203,6 +206,11 @@ const home = localizePath("/", lang);
     const zoomLabel = content.dataset.zoomLabel ?? "";
 
     for (const img of Array.from(content.querySelectorAll("img"))) {
+      // A linked image — `[![alt](img)](url)` in Markdown — would nest this
+      // button inside an <a>, which is invalid and would both navigate and
+      // open the lightbox on one click. Leave the link as the control.
+      if (img.closest("a")) continue;
+
       const button = document.createElement("button");
       button.type = "button";
       button.className = "doc-zoom-btn";

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -51,7 +51,7 @@ const home = localizePath("/", lang);
         type="button"
         class="lg:hidden text-on-surface-muted hover:text-white transition-colors p-1"
         data-sidebar-toggle
-        aria-label={t("a11y.toggleSidebar")}
+        aria-label={t("a11y.docsSections")}
         aria-expanded="false"
         aria-controls="docs-sidebar"
       >
@@ -89,7 +89,7 @@ const home = localizePath("/", lang);
       <nav
         id="docs-sidebar"
         class="docs-sidebar w-60 h-full bg-surface-raised/30 backdrop-blur-xl border-r border-border p-4 overflow-y-auto"
-        aria-label={t("a11y.toggleSidebar")}
+        aria-label={t("a11y.docsSections")}
       >
         {groups.map((group, i) => (
           <div class="mb-6">

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -42,14 +42,18 @@ const home = localizePath("/", lang);
 </script>
 
 <div class="min-h-screen bg-community-bg text-on-surface font-sans" data-docs-root>
-  <nav class="h-14 bg-surface border-b border-border flex items-center justify-between px-4 lg:px-6 sticky top-0 z-50">
+  <nav
+    class="h-14 bg-surface border-b border-border flex items-center justify-between px-4 lg:px-6 sticky top-0 z-50"
+    aria-label={t("a11y.primaryNav")}
+  >
     <div class="flex items-center gap-3">
       <button
         type="button"
         class="lg:hidden text-on-surface-muted hover:text-white transition-colors p-1"
         data-sidebar-toggle
-        aria-label="Toggle sidebar"
+        aria-label={t("a11y.toggleSidebar")}
         aria-expanded="false"
+        aria-controls="docs-sidebar"
       >
         <span data-icon-menu><Menu class="w-5 h-5" /></span>
         <span data-icon-close class="hidden"><X class="w-5 h-5" /></span>
@@ -75,31 +79,52 @@ const home = localizePath("/", lang);
 
   <div class="flex">
     <div class="docs-sidebar-backdrop" data-sidebar-backdrop aria-hidden="true"></div>
-    <aside class="docs-sidebar-aside" data-sidebar>
-      <div class="docs-sidebar w-60 h-full bg-surface-raised/30 backdrop-blur-xl border-r border-border p-4 overflow-y-auto">
-        {groups.map((group) => (
+    {/* A plain div, not <aside>: this is only the positioning/drawer wrapper,
+        and as an <aside> it exposed a second, unnamed `complementary` landmark
+        wrapping the `navigation` one that actually holds the links. */}
+    <div class="docs-sidebar-aside" data-sidebar>
+      {/* A <nav>, not a bare div — this is the docs' section navigation and it
+          needs to be reachable as a landmark and distinguishable from the top
+          nav. Each group is a labelled list so its size is announced. */}
+      <nav
+        id="docs-sidebar"
+        class="docs-sidebar w-60 h-full bg-surface-raised/30 backdrop-blur-xl border-r border-border p-4 overflow-y-auto"
+        aria-label={t("a11y.toggleSidebar")}
+      >
+        {groups.map((group, i) => (
           <div class="mb-6">
-            <div class="text-xs font-bold uppercase tracking-widest text-vibrant-orange mb-2 px-2">
+            {/* Deliberately not a heading: the <ul> borrows it via
+                aria-labelledby, so the group is announced without injecting
+                sidebar entries into the page's own heading outline. */}
+            <div
+              id={`docs-sidebar-group-${i}`}
+              class="text-xs font-bold uppercase tracking-widest text-vibrant-orange mb-2 px-2"
+            >
               {group.label}
             </div>
-            {group.pages.map((page) => (
-              <a
-                href={localizePath(`/docs/${page.slug}`, lang)}
-                class={`block text-sm rounded-lg px-3 py-2 mb-0.5 transition-colors ${
-                  page.slug === slug
-                    ? "bg-red-cta text-white font-semibold"
-                    : "text-on-surface-muted hover:bg-surface-raised/40"
-                }`}
-              >
-                {page.title}
-              </a>
-            ))}
+            <ul aria-labelledby={`docs-sidebar-group-${i}`}>
+              {group.pages.map((page) => (
+                <li>
+                  <a
+                    href={localizePath(`/docs/${page.slug}`, lang)}
+                    {...(page.slug === slug ? { "aria-current": "page" } : {})}
+                    class={`block text-sm rounded-lg px-3 py-2 mb-0.5 transition-colors ${
+                      page.slug === slug
+                        ? "bg-red-cta text-white font-semibold"
+                        : "text-on-surface-muted hover:bg-surface-raised/40"
+                    }`}
+                  >
+                    {page.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
           </div>
         ))}
-      </div>
-    </aside>
+      </nav>
+    </div>
 
-    <main class="flex-1 p-6 lg:py-10 lg:px-12 overflow-y-auto bg-community-bg">
+    <main id="main-content" class="flex-1 p-6 lg:py-10 lg:px-12 overflow-y-auto bg-community-bg">
       <div class="max-w-[760px]">
         <div class="prose" data-docs-content data-pagefind-body data-zoom-label={t("docs.image.zoom")}>
           <slot />

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -87,7 +87,7 @@ const home = localizePath("/", lang);
                 href={localizePath(`/docs/${page.slug}`, lang)}
                 class={`block text-sm rounded-lg px-3 py-2 mb-0.5 transition-colors ${
                   page.slug === slug
-                    ? "bg-vibrant-red text-white font-semibold"
+                    ? "bg-red-cta text-white font-semibold"
                     : "text-on-surface-muted hover:bg-surface-raised/40"
                 }`}
               >
@@ -101,7 +101,7 @@ const home = localizePath("/", lang);
 
     <main class="flex-1 p-6 lg:py-10 lg:px-12 overflow-y-auto bg-community-bg">
       <div class="max-w-[760px]">
-        <div class="prose" data-docs-content data-pagefind-body>
+        <div class="prose" data-docs-content data-pagefind-body data-zoom-label={t("docs.image.zoom")}>
           <slot />
         </div>
         {(prev || next) && (
@@ -137,6 +137,29 @@ const home = localizePath("/", lang);
 
     <TableOfContents lang={lang} headings={headings} />
   </div>
+
+  {/* Image lightbox. A native <dialog> opened with showModal(), so focus
+      trapping, Esc-to-close and focus restore to the thumbnail are the
+      platform's job. Populated by the script below. */}
+  <dialog class="doc-modal" data-doc-lightbox data-pagefind-ignore>
+    {/* Transparent 1x1 placeholder rather than src="" — the latter re-requests
+        the page URL in some browsers. The script swaps in the real image
+        before the dialog is ever shown. */}
+    <img
+      class="doc-modal-img"
+      data-doc-lightbox-img
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+      alt=""
+    />
+    <button
+      type="button"
+      class="doc-modal-close"
+      data-doc-lightbox-close
+      aria-label={t("docs.image.close")}
+    >
+      <X class="w-5 h-5" />
+    </button>
+  </dialog>
 </div>
 
 <script>
@@ -156,30 +179,57 @@ const home = localizePath("/", lang);
     setSidebar(!root?.classList.contains("docs-sidebar-open")),
   );
   backdrop?.addEventListener("click", () => setSidebar(false));
-
-  // Image lightbox: zoom any .prose img on click (progressive enhancement).
-  const content = document.querySelector("[data-docs-content]");
-  let modal: HTMLDivElement | null = null;
-  function closeModal() {
-    modal?.remove();
-    modal = null;
-    document.body.style.overflow = "";
-  }
-  content?.addEventListener("click", (e) => {
-    const img = e.target;
-    if (!(img instanceof HTMLImageElement)) return;
-    modal = document.createElement("div");
-    modal.className = "doc-modal-backdrop";
-    const big = document.createElement("img");
-    big.src = img.src;
-    big.alt = img.alt;
-    big.className = "doc-modal-img";
-    modal.appendChild(big);
-    modal.addEventListener("click", closeModal);
-    document.body.appendChild(modal);
-    document.body.style.overflow = "hidden";
-  });
+  // Escape closes the drawer and hands focus back to the button that opened it.
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeModal();
+    if (e.key !== "Escape" || !root?.classList.contains("docs-sidebar-open")) return;
+    setSidebar(false);
+    (toggle as HTMLElement | null)?.focus();
   });
+
+  /*
+   * Image lightbox (progressive enhancement). Each content image is wrapped in
+   * a real <button> so it can be focused and activated from the keyboard — the
+   * previous version bound a click handler straight to the <img>, which is
+   * unreachable without a mouse. The overlay is a native <dialog> opened with
+   * showModal(), so the focus trap, Esc-to-close and focus restore back to the
+   * thumbnail all come from the platform.
+   */
+  const content = document.querySelector<HTMLElement>("[data-docs-content]");
+  const lightbox = document.querySelector<HTMLDialogElement>("[data-doc-lightbox]");
+  const lightboxImg = lightbox?.querySelector<HTMLImageElement>("[data-doc-lightbox-img]");
+  const lightboxClose = lightbox?.querySelector<HTMLButtonElement>("[data-doc-lightbox-close]");
+
+  if (content && lightbox && lightboxImg && lightboxClose) {
+    const zoomLabel = content.dataset.zoomLabel ?? "";
+
+    for (const img of Array.from(content.querySelectorAll("img"))) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "doc-zoom-btn";
+      // The image's alt text is the subject; the label names the action on it,
+      // matching how the landing-page gallery labels its own zoom buttons.
+      button.setAttribute("aria-label", `${zoomLabel} ${img.alt}`.trim());
+      img.replaceWith(button);
+      button.appendChild(img);
+
+      button.addEventListener("click", () => {
+        // currentSrc resolves whichever <source> the browser actually picked.
+        lightboxImg.src = img.currentSrc || img.src;
+        lightboxImg.alt = img.alt;
+        lightbox.setAttribute("aria-label", img.alt);
+        lightbox.showModal();
+        document.body.style.overflow = "hidden";
+      });
+    }
+
+    lightboxClose.addEventListener("click", () => lightbox.close());
+    // Clicking the backdrop area — the dialog itself, outside the image — closes.
+    lightbox.addEventListener("click", (e) => {
+      if (e.target === lightbox) lightbox.close();
+    });
+    // Fires for Esc and the close button alike, so the scroll lock lifts once.
+    lightbox.addEventListener("close", () => {
+      document.body.style.overflow = "";
+    });
+  }
 </script>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -43,10 +43,13 @@ const home = localizePath("/", lang);
 
 <div class="min-h-screen bg-community-bg text-on-surface font-sans" data-docs-root>
   <nav
-    class="h-14 bg-surface border-b border-border flex items-center justify-between px-4 lg:px-6 sticky top-0 z-50"
+    class="h-14 bg-surface border-b border-border flex items-center justify-between px-3 sm:px-4 lg:px-6 sticky top-0 z-50"
     aria-label={t("a11y.primaryNav")}
   >
-    <div class="flex items-center gap-3">
+    {/* Tighter padding and gaps below `sm`: at 390px the row measured 410px
+        wide, pushing the language switcher off-canvas and making the page
+        scroll sideways (WCAG 1.4.10). */}
+    <div class="flex items-center gap-2 sm:gap-3">
       <button
         type="button"
         class="lg:hidden text-on-surface-muted hover:text-white transition-colors p-1"
@@ -64,7 +67,7 @@ const home = localizePath("/", lang);
       </a>
       <span class="hidden sm:inline text-on-surface-muted text-sm">{t("docs.slash")}</span>
     </div>
-    <div class="flex items-center gap-3">
+    <div class="flex items-center gap-2 sm:gap-3">
       <DocsSearch lang={lang} />
       <PlatformSwitcher lang={lang} client:idle />
       <LanguageSwitcher lang={lang} pathname={pathname} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,6 +68,16 @@ const ptHref = lang === 'pt' ? pathname : altPath;
     <meta name="twitter:image" content={ogImageUrl} />
 
     <meta name="generator" content={Astro.generator} />
+
+    {/* The scroll-reveal entrance starts elements at opacity 0 and relies on an
+        IntersectionObserver to reveal them. With scripting off that observer
+        never runs, so most of the page would render blank rather than merely
+        un-animated. */}
+    <noscript>
+      <style>
+        .scroll-reveal { opacity: 1 !important; transform: none !important; transition: none !important; }
+      </style>
+    </noscript>
   </head>
   <body>
     {/* First stop in the tab order on every page, so keyboard and screen

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -76,6 +76,11 @@ const ptHref = lang === 'pt' ? pathname : altPath;
     <noscript>
       <style>
         .scroll-reveal { opacity: 1 !important; transform: none !important; transition: none !important; }
+        /* Motion islands server-render their entrance state as an inline
+           style="opacity:0;transform:…", which no class selector can reach.
+           Without this the radios grid renders 22 invisible cards and the FAQ
+           renders none of its questions. */
+        [style*="opacity:0"] { opacity: 1 !important; transform: none !important; }
       </style>
     </noscript>
   </head>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,7 +7,7 @@ import '@fontsource/poppins/700.css';
 import '@fontsource/space-mono/400.css';
 import '@fontsource/space-mono/700.css';
 import '@/src/index.css';
-import type { Lang } from '@/src/i18n/t';
+import { getT, type Lang } from '@/src/i18n/t';
 import { altLocalePath } from '@/src/i18n/routing';
 
 interface Props {
@@ -26,6 +26,7 @@ const {
   ogImage = '/social.jpg',
 } = Astro.props;
 
+const t = getT(lang);
 const site = Astro.site?.toString().replace(/\/$/, '') ?? 'https://www.voxdmr.com';
 const canonical = site + pathname;
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : site + ogImage;
@@ -69,6 +70,10 @@ const ptHref = lang === 'pt' ? pathname : altPath;
     <meta name="generator" content={Astro.generator} />
   </head>
   <body>
+    {/* First stop in the tab order on every page, so keyboard and screen
+        reader users can jump the nav instead of tabbing through it each time.
+        Off-screen until focused; every page's main region carries the id. */}
+    <a href="#main-content" class="skip-link">{t('a11y.skipToContent')}</a>
     <slot />
   </body>
 </html>

--- a/src/lib/rehype-anchor-label.ts
+++ b/src/lib/rehype-anchor-label.ts
@@ -1,0 +1,34 @@
+import { visit } from "unist-util-visit";
+import type { Root, Element } from "hast";
+import type { VFile } from "vfile";
+
+/** Same convention as remark-platform: the locale comes from the file path. */
+function langFromPath(path: string | undefined): "en" | "pt" {
+  return path && /(^|\/)pt\//.test(path) ? "pt" : "en";
+}
+
+const LABELS = {
+  en: "Permalink to this section",
+  pt: "Ligação permanente para esta secção",
+} as const;
+
+/**
+ * Localizes the heading permalink label that rehype-autolink-headings attaches.
+ * Its `properties` are static config, so the English string was being announced
+ * on the Portuguese docs too. Runs after the autolink plugin and rewrites the
+ * label per the file's locale.
+ */
+export function rehypeAnchorLabel() {
+  return (tree: Root, file: VFile) => {
+    const label = LABELS[langFromPath(file.path)];
+    visit(tree, "element", (node: Element) => {
+      if (
+        node.tagName === "a" &&
+        Array.isArray(node.properties?.className) &&
+        node.properties.className.includes("heading-anchor")
+      ) {
+        node.properties["aria-label"] = label;
+      }
+    });
+  };
+}

--- a/src/lib/release.ts
+++ b/src/lib/release.ts
@@ -43,19 +43,37 @@ interface ReleaseAsset {
 let cached: Promise<Download[]> | null = null;
 
 async function fetchAssets(): Promise<ReleaseAsset[] | null> {
+  // Unauthenticated GitHub allows 60 requests/hour *per IP*, and CI runners
+  // share IPs — so an unauthenticated build is one that quietly falls back
+  // whenever a neighbour has used up the budget. The deploy workflow passes
+  // the token it already has, which raises this to 5000/hour.
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "voxdmr-site-build",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
   try {
-    const res = await fetch(API, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "voxdmr-site-build",
-      },
-    });
+    const res = await fetch(API, { headers });
     if (!res.ok) {
-      console.warn(`[downloads] GitHub API returned ${res.status}; using fallback URLs.`);
+      const remaining = res.headers.get("x-ratelimit-remaining");
+      const rateLimited = res.status === 403 && remaining === "0";
+      console.warn(
+        `[downloads] GitHub API returned ${res.status}` +
+          (remaining === null ? "" : ` (rate limit remaining: ${remaining})`) +
+          "; using fallback URLs." +
+          (rateLimited && !token
+            ? " Set GITHUB_TOKEN to authenticate — the unauthenticated limit is 60/hour per IP."
+            : ""),
+      );
       return null;
     }
     const release = (await res.json()) as { tag_name?: string; assets?: ReleaseAsset[] };
-    console.log(`[downloads] resolved against release ${release.tag_name ?? "?"}`);
+    console.log(
+      `[downloads] resolved against release ${release.tag_name ?? "?"}` +
+        ` (${token ? "authenticated" : "unauthenticated"})`,
+    );
     return release.assets ?? [];
   } catch (err) {
     // An unreachable network must not break the build — a stale-but-valid URL

--- a/src/lib/release.ts
+++ b/src/lib/release.ts
@@ -1,0 +1,106 @@
+import { downloads, type Download } from "../downloads";
+
+/**
+ * Resolves the download targets against the actual assets of the latest GitHub
+ * release, at build time.
+ *
+ * The alternative — calling the API from the browser — is a trap for a public
+ * site: unauthenticated GitHub is 60 requests/hour *per IP*, so everyone behind
+ * one corporate NAT or mobile carrier shares that budget, and there is no way
+ * to raise it without shipping a token. Resolving here means one request per
+ * build instead of one per visitor, the URLs land in static HTML, and the
+ * download links keep working with JavaScript off.
+ *
+ * The trade-off is that a new release does not reach the site until the site
+ * rebuilds — wire a repository_dispatch from the release workflow if that gap
+ * matters.
+ */
+
+const REPO = "jcalado/voxdmr-site";
+const API = `https://api.github.com/repos/${REPO}/releases/latest`;
+
+/**
+ * How to find each target among the release assets. Kept out of the `Download`
+ * type on purpose: those objects are serialized into the DownloadMenu island's
+ * props, and a RegExp does not survive JSON.
+ *
+ * Patterns are specific enough not to collide — the release carries both a bare
+ * `VoxDMR-linux-x86_64` and a `.AppImage`, and three APKs of which only
+ * armeabi-v7a is the 32-bit build.
+ */
+const ASSET_PATTERNS: Partial<Record<Download["key"], RegExp>> = {
+  windows: /^VoxDMR-windows-.*\.exe$/i,
+  linuxAppImage: /\.AppImage$/i,
+  apk32: /armeabi-v7a\.apk$/i,
+};
+
+interface ReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+/** One fetch per process, not per page — Astro renders many pages per build. */
+let cached: Promise<Download[]> | null = null;
+
+async function fetchAssets(): Promise<ReleaseAsset[] | null> {
+  try {
+    const res = await fetch(API, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "voxdmr-site-build",
+      },
+    });
+    if (!res.ok) {
+      console.warn(`[downloads] GitHub API returned ${res.status}; using fallback URLs.`);
+      return null;
+    }
+    const release = (await res.json()) as { tag_name?: string; assets?: ReleaseAsset[] };
+    console.log(`[downloads] resolved against release ${release.tag_name ?? "?"}`);
+    return release.assets ?? [];
+  } catch (err) {
+    // An unreachable network must not break the build — a stale-but-valid URL
+    // beats no site at all.
+    console.warn(`[downloads] could not reach the GitHub API (${(err as Error).message}); using fallback URLs.`);
+    return null;
+  }
+}
+
+async function resolve(): Promise<Download[]> {
+  const assets = await fetchAssets();
+  if (!assets) return downloads;
+
+  const missing: string[] = [];
+  const resolved = downloads.map((d) => {
+    const pattern = ASSET_PATTERNS[d.key];
+    if (!pattern) return d; // Play Store isn't a GitHub asset.
+
+    const match = assets.find((a) => pattern.test(a.name));
+    if (!match) {
+      missing.push(`${d.key} (no asset matching ${pattern})`);
+      return d;
+    }
+    // A resolved asset is a direct file link, so it downloads in place rather
+    // than opening a tab — this is what turns the version-stamped APK from a
+    // "go and find it" page link into an actual download.
+    return { ...d, href: match.browser_download_url, external: false };
+  });
+
+  if (missing.length) {
+    const detail = missing.join(", ");
+    const hint =
+      `[downloads] the latest release has no asset for: ${detail}. ` +
+      `Assets present: ${assets.map((a) => a.name).join(", ")}`;
+    // The API answered, so this is real drift — an asset was renamed or
+    // dropped — not a transient network problem. Fail the production build
+    // rather than shipping links that 404.
+    if (import.meta.env.PROD) throw new Error(hint);
+    console.warn(hint);
+  }
+
+  return resolved;
+}
+
+export function resolveDownloads(): Promise<Download[]> {
+  cached ??= resolve();
+  return cached;
+}

--- a/src/pages/brandmeister-password.astro
+++ b/src/pages/brandmeister-password.astro
@@ -74,6 +74,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                   class="inline-block mt-2 font-mono text-sm text-vibrant-blue underline underline-offset-2 hover:decoration-2 break-all"
                 >
                   {step.href}
+                  <span class="sr-only"> ({t('a11y.newTab', lang)})</span>
                 </a>
               )}
             </div>
@@ -127,7 +128,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                       target="_blank"
                       rel="noopener noreferrer"
                       class="text-vibrant-blue underline underline-offset-2 hover:decoration-2"
-                    >{t('bmpw.trouble.selfcare', lang)}</a>,
+                    >{t('bmpw.trouble.selfcare', lang)}<span class="sr-only"> ({t('a11y.newTab', lang)})</span></a>,
                     part,
                   ]
             )}

--- a/src/pages/brandmeister-password.astro
+++ b/src/pages/brandmeister-password.astro
@@ -33,7 +33,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
   <div class="min-h-screen bg-community-bg text-on-surface font-sans">
     <SiteNav lang={lang} pathname={pathname} />
 
-    <main class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+    <main id="main-content" class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <p class="text-xs font-bold uppercase tracking-[0.18em] text-vibrant-red mb-4">
         {t('bmpw.eyebrow', lang)}
       </p>
@@ -71,7 +71,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                   href={step.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-block mt-2 font-mono text-sm text-vibrant-blue hover:underline break-all"
+                  class="inline-block mt-2 font-mono text-sm text-vibrant-blue underline underline-offset-2 hover:decoration-2 break-all"
                 >
                   {step.href}
                 </a>
@@ -91,7 +91,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
       <!-- Mock profile field -->
       <div class="rounded-3xl bg-surface-raised/40 border border-white/[0.07] p-6 mb-12">
         <div class="flex items-center gap-2.5 mb-5">
-          <span class="inline-flex items-center rounded-full bg-vibrant-red/15 text-vibrant-red text-xs font-bold uppercase tracking-wider px-3 py-1">
+          <span class="inline-flex items-center rounded-full bg-vibrant-red/15 text-red-400 text-xs font-bold uppercase tracking-wider px-3 py-1">
             BrandMeister
           </span>
           <span class="text-sm text-on-surface-muted">{t('bmpw.mock.addProfile', lang)}</span>
@@ -126,7 +126,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                       href="https://brandmeister.network/"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="text-vibrant-blue hover:underline"
+                      class="text-vibrant-blue underline underline-offset-2 hover:decoration-2"
                     >{t('bmpw.trouble.selfcare', lang)}</a>,
                     part,
                   ]

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -15,7 +15,7 @@ const description = t('privacy.overview.text', lang);
   <div class="min-h-screen bg-community-bg text-on-surface font-sans">
     <SiteNav lang={lang} pathname={pathname} />
 
-    <main class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+    <main id="main-content" class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <h1 class="text-4xl lg:text-5xl font-headline font-bold text-white mb-2 tracking-tight">
         {t('privacy.title', lang)}
       </h1>
@@ -89,7 +89,7 @@ const description = t('privacy.overview.text', lang);
           <h2 class="text-2xl font-headline font-bold text-white mb-4">{t('privacy.contact.title', lang)}</h2>
           <p>
             {t('privacy.contact.text', lang)}{' '}
-            <a href="mailto:voxdmr@jcalado.com" class="text-vibrant-blue hover:underline">voxdmr@jcalado.com</a>
+            <a href="mailto:voxdmr@jcalado.com" class="text-vibrant-blue underline underline-offset-2 hover:decoration-2">voxdmr@jcalado.com</a>
           </p>
         </section>
       </div>

--- a/src/pages/pt/brandmeister-password.astro
+++ b/src/pages/pt/brandmeister-password.astro
@@ -74,6 +74,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                   class="inline-block mt-2 font-mono text-sm text-vibrant-blue underline underline-offset-2 hover:decoration-2 break-all"
                 >
                   {step.href}
+                  <span class="sr-only"> ({t('a11y.newTab', lang)})</span>
                 </a>
               )}
             </div>
@@ -127,7 +128,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                       target="_blank"
                       rel="noopener noreferrer"
                       class="text-vibrant-blue underline underline-offset-2 hover:decoration-2"
-                    >{t('bmpw.trouble.selfcare', lang)}</a>,
+                    >{t('bmpw.trouble.selfcare', lang)}<span class="sr-only"> ({t('a11y.newTab', lang)})</span></a>,
                     part,
                   ]
             )}

--- a/src/pages/pt/brandmeister-password.astro
+++ b/src/pages/pt/brandmeister-password.astro
@@ -33,7 +33,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
   <div class="min-h-screen bg-community-bg text-on-surface font-sans">
     <SiteNav lang={lang} pathname={pathname} />
 
-    <main class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+    <main id="main-content" class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <p class="text-xs font-bold uppercase tracking-[0.18em] text-vibrant-red mb-4">
         {t('bmpw.eyebrow', lang)}
       </p>
@@ -71,7 +71,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                   href={step.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-block mt-2 font-mono text-sm text-vibrant-blue hover:underline break-all"
+                  class="inline-block mt-2 font-mono text-sm text-vibrant-blue underline underline-offset-2 hover:decoration-2 break-all"
                 >
                   {step.href}
                 </a>
@@ -91,7 +91,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
       <!-- Mock profile field -->
       <div class="rounded-3xl bg-surface-raised/40 border border-white/[0.07] p-6 mb-12">
         <div class="flex items-center gap-2.5 mb-5">
-          <span class="inline-flex items-center rounded-full bg-vibrant-red/15 text-vibrant-red text-xs font-bold uppercase tracking-wider px-3 py-1">
+          <span class="inline-flex items-center rounded-full bg-vibrant-red/15 text-red-400 text-xs font-bold uppercase tracking-wider px-3 py-1">
             BrandMeister
           </span>
           <span class="text-sm text-on-surface-muted">{t('bmpw.mock.addProfile', lang)}</span>
@@ -126,7 +126,7 @@ const [introBefore, introAfter] = t('bmpw.intro', lang).split(highlight);
                       href="https://brandmeister.network/"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="text-vibrant-blue hover:underline"
+                      class="text-vibrant-blue underline underline-offset-2 hover:decoration-2"
                     >{t('bmpw.trouble.selfcare', lang)}</a>,
                     part,
                   ]

--- a/src/pages/pt/privacy.astro
+++ b/src/pages/pt/privacy.astro
@@ -15,7 +15,7 @@ const description = t('privacy.overview.text', lang);
   <div class="min-h-screen bg-community-bg text-on-surface font-sans">
     <SiteNav lang={lang} pathname={pathname} />
 
-    <main class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+    <main id="main-content" class="max-w-3xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <h1 class="text-4xl lg:text-5xl font-headline font-bold text-white mb-2 tracking-tight">
         {t('privacy.title', lang)}
       </h1>
@@ -89,7 +89,7 @@ const description = t('privacy.overview.text', lang);
           <h2 class="text-2xl font-headline font-bold text-white mb-4">{t('privacy.contact.title', lang)}</h2>
           <p>
             {t('privacy.contact.text', lang)}{' '}
-            <a href="mailto:voxdmr@jcalado.com" class="text-vibrant-blue hover:underline">voxdmr@jcalado.com</a>
+            <a href="mailto:voxdmr@jcalado.com" class="text-vibrant-blue underline underline-offset-2 hover:decoration-2">voxdmr@jcalado.com</a>
           </p>
         </section>
       </div>

--- a/src/pages/pt/radios.astro
+++ b/src/pages/pt/radios.astro
@@ -16,7 +16,7 @@ const description = t('radios.metaDescription', lang);
   <div class="min-h-screen bg-community-bg text-on-surface font-sans">
     <SiteNav lang={lang} pathname={pathname} />
 
-    <main class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+    <main id="main-content" class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <h1 class="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t('radios.title', lang)}</h1>
       <p class="text-on-surface-muted mb-8 max-w-2xl leading-relaxed">{t('radios.intro', lang)}</p>
 

--- a/src/pages/radios.astro
+++ b/src/pages/radios.astro
@@ -16,7 +16,7 @@ const description = t('radios.metaDescription', lang);
   <div class="min-h-screen bg-community-bg text-on-surface font-sans">
     <SiteNav lang={lang} pathname={pathname} />
 
-    <main class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+    <main id="main-content" class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <h1 class="text-4xl lg:text-5xl font-headline font-bold text-white mb-4 tracking-tight">{t('radios.title', lang)}</h1>
       <p class="text-on-surface-muted mb-8 max-w-2xl leading-relaxed">{t('radios.intro', lang)}</p>
 


### PR DESCRIPTION
Accessibility audit of the whole site, worked through in three phases, plus two follow-ups that came out of it. Every phase was reviewed and the review findings fixed before moving on.

**Result: `npm run test:a11y` reports 0 violations across 27 checks** — 11 pages × both locales × two viewports, plus five opened interactive states.

## P0 — things that blocked someone outright

- **Every filled CTA failed contrast.** White on `--color-vibrant-red` (#EF4444) is **3.76:1**, under the 4.5:1 AA floor, and it backed every primary button on the site. New `--color-red-cta` (#DC2626, 4.83:1) / `--color-red-cta-hover` (#B91C1C) for red fills carrying white text. `vibrant-red` stays the accent for red *text* on dark. Note the previous `hover:bg-red-500` was a no-op — the token already *was* red-500.
- **`DownloadMenu` was unreachable by keyboard.** Portalled to `<body>`, so Tab from the trigger skipped it entirely, and it claimed `role="menu"` without implementing the pattern. Now: focus moves in on a keyboard open, arrow/Home/End roving, Escape and Tab return focus to the trigger, closes on focus-out.
- **The docs sidebar drawer stayed in the tab order while closed** — hidden with `transform` alone, leaving every link focusable off-screen on mobile.
- **An unlabeled button below `sm`** — the platform switcher's inactive button has a `display:none` text label there, leaving only a decorative icon.
- **The docs image lightbox was mouse-only** — a click handler on a non-focusable `<img>`, opening a div with no dialog semantics or focus restore. Content images are wrapped in real buttons now and the overlay is a native `<dialog>`.

## P1 — landmarks, focus, announcements

- Skip link on every page; the landing page had **no `<main>` at all**.
- Docs sidebar was a bare div of links inside an unnamed `<aside>` — now a labelled `<nav>`; all navs named so the two on a docs page are distinguishable; `aria-current` on active links.
- **Site-wide `:focus-visible` outline** — most controls had none of their own and fell back to a UA outline that is near-invisible on these backgrounds in Firefox.
- Docs search is a real combobox (`aria-expanded`, `aria-activedescendant`) — arrow-key movement through results was completely silent before. Radios filtering announces its result count.
- `"Toggle menu"` / `"Toggle sidebar"` were **hardcoded English on the Portuguese site**.
- **Docs prose links were colour-only at 1.97:1 against body text** (WCAG 1.4.1, Level A) — underlined now, along with the inline links on the privacy and BrandMeister pages.

## P2 — remaining contrast, hints, tooling

- Shiki's default `github-dark` renders code comments at **3.04:1**; `github-dark-default` brings the weakest token to 6.15:1.
- `rehype-autolink-headings`' aria-label is static config, so every heading permalink on the **Portuguese** docs announced "Permalink to this section" in English. A small rehype pass localizes it.
- All 17 `target="_blank"` links carry an off-screen "opens in a new tab" note, in both locales.
- **`.scroll-reveal` starts at `opacity: 0`**, so with JS off the landing page rendered essentially blank. A `<noscript>` block fixes it — 16 of 16 elements visible now, previously 0.
- `npm run test:a11y` — axe-core over the built site, exits non-zero on any violation.

## Two things the reviews caught that are worth calling out

**The test harness was unsound and I'd reported a false pass.** axe does not evaluate text at `opacity: 0` — it neither passes nor flags it. The motion islands server-render an inline `style="opacity:0"`, and my scroll-to-reveal pass was synchronous, so the IntersectionObserver only ever saw the final position. **Every radio card, every FAQ question and the whole gallery were silently exempt from the audit.** The suite now fails a page outright if any text is still invisible when axe runs, which immediately surfaced two real violations it had been hiding. Adding a 390px pass then caught the docs nav overflowing to 410px and scrolling the page sideways (WCAG 1.4.10, pre-existing on `main`).

**The no-JS fallback had the same blind spot** — it only reached `.scroll-reveal`, so `/radios` rendered 22 invisible cards with scripting off.

## Follow-ups

**Footer download links** — every "Download" affordance is a button that reveals its targets only on activation, so the four targets were absent from a screen reader's links list (the fastest way most screen reader users scan a page). The only listed route to a download was the GitHub link, which lands on a releases page. Landing page now: **1 route → 5**.

**Build-time release resolution** — the download URLs were hand-written guesses at asset filenames. They happened to be right, but nothing tied them to reality; rename an artifact and they 404 silently. The APK was worse, pointing at a page rather than a file because its filename is version-stamped. `src/lib/release.ts` now resolves against the latest release's actual assets at build time — the APK is a real direct download.

Resolved at build rather than in the browser deliberately: unauthenticated GitHub is 60 req/hour **per IP**, so one NAT'd office would break the links for everyone behind it, with no way to raise it from client-side code.

- API unreachable → warn, fall back, build succeeds.
- Asset renamed (API answered, pattern missed) → **production build fails**, naming the pattern and listing every asset present.

Both tested. **A new release does not reach the site until the site rebuilds** — a `repository_dispatch` from the release workflow would close that gap if it matters.

## Notes for review

- The one deliberate rule suppression is `region` on the download-menu state only, with the reason inline: the menu is portalled to `<body>` to escape a `backdrop-filter` ancestor, which necessarily puts it outside every landmark. Best-practice rule, not WCAG.
- Visible design changes are limited to: red fills a step darker, docs prose links underlined, a new code theme, and a download row in the footer.
- `/docs` and `public/404.html` are meta-refresh redirect stubs with no `lang` and no `<main>` — 5 violations if added to the suite. Left alone, but they are user-reachable URLs.
- The suite needs a Chromium once: `npx playwright install chromium`, or `CHROME_PATH=/usr/bin/chromium npm run test:a11y`. Worth pinning down before wiring into CI.
- **Not fixed:** the nav and hero CTAs are still dropdowns, so a screen reader user tabbing from the top still meets a button before a link. The footer route is a fallback for the scan-the-links workflow, not a replacement. Making the primary CTA itself a link is a visible design decision and was left for you.
