### PR TITLE
ci: rebuild the site when a release is published

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,12 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  # The build resolves the download links against the latest release's assets,
+  # so publishing a release has to rebuild the site or the links keep pointing
+  # at the previous version. Releases are cut in this repo, so this is a plain
+  # `release` trigger — no repository_dispatch or cross-repo token needed.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -18,7 +24,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Always build the current main. On a `release` event the default
+      # checkout is the tagged commit, which would deploy the site as it looked
+      # at the tag rather than as it is now — the release is a trigger to
+      # re-resolve the download links, not the content to publish.
       - uses: actions/checkout@v7
+        with:
+          ref: main
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
Follow-up to #168. The build now resolves the download links against the latest release's assets, so until the site rebuilds those links still point at the previous version. This closes that gap.

## Not `repository_dispatch`

I suggested that in #168 on the assumption the app lived in a separate repo. It doesn't — releases are cut in this repo:

```
v0.15.1   author: jcalado   target: main
```

`repository_dispatch` exists to bridge a cross-repo hop. There isn't one here, so it would only add a PAT to store and rotate, plus a dispatch payload to keep in sync, for no benefit. A plain `release: [published]` trigger does the same job with no secrets.

## Why checkout is pinned to `main`

On a `release` event the default checkout is the **tagged commit**, which would publish the site as it looked at the tag rather than as it is now — silently reverting any site changes merged since. The release is a trigger to re-resolve the download links, not the content to deploy, so `ref: main` is what's wanted.

The existing `concurrency: group: pages, cancel-in-progress: true` already covers a release landing at the same time as a push to main.

## Verifying it

It can't be tested before merge — workflow triggers only take effect from the default branch. After merging, either publish a release, or confirm the wiring with `gh workflow run deploy.yml` and check the build log says:

```
[downloads] resolved against release <tag> (authenticated)
```
